### PR TITLE
Implement take_until_parser_matches

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -506,14 +506,13 @@ pub fn take_until_parser_matches<F, Input, O, Error>(
   mut f: F,
 ) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTake + InputLength + Clone,
+  Input: InputTake + InputIter + InputLength + Clone,
   F: Parser<Input, O, Error>,
   Error: ParseError<Input>,
 {
   move |input: Input| {
     let i = input.clone();
-    let input_length = i.input_len();
-    for ind in 0..=input_length {
+    for (ind, _) in i.iter_indices() {
       let (remaining, _taken) = i.take_split(ind);
       match f.parse(remaining) {
         Err(_) => (),
@@ -521,6 +520,17 @@ where
           let res: IResult<Input, Input, Error> = Ok(i.take_split(ind));
           return res;
         }
+      }
+    }
+    // Attempt to match one last time past the end of the input. This
+    // allows for 0-length combinators to be used (for example, an eof
+    // combinator).
+    let (remaining, _taken) = i.take_split(i.input_len());
+    match f.parse(remaining) {
+      Err(_) => (),
+      Ok(_) => {
+        let res: IResult<Input, Input, Error> = Ok(i.take_split(i.input_len()));
+        return res;
       }
     }
     Err(Err::Error(Error::from_error_kind(

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -482,7 +482,7 @@ where
 /// To show the power of this parser we will parse a line containing
 /// a set of flags at the end surrounded by brackets. Example:
 /// "Submit a PR [inprogress]"
-/// ```rust
+/// ```ignore
 /// # #[macro_use] extern crate nom;
 /// # use nom::{Err, error::ErrorKind, IResult};
 /// use nom::bytes::complete::{is_not, take_until_parser_matches, tag};

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -453,6 +453,16 @@ where
 /// It doesn't consume the input to the parser. It will return `Err(Err::Error((_, ErrorKind::TakeUntilParserMatches)))`
 /// if the pattern wasn't met
 ///
+/// The performance of this parser depends HEAVILY on the inner parser
+/// failing early. For each step on the input, this will run the inner
+/// parser against the remaining input, so if the inner parser does
+/// not fail fast then you will end up re-parsing the remaining input
+/// repeatedly.
+///
+/// If you are looking to match until a string
+/// (`take_until_parser_matches(tag("foo"))`) it would be faster to
+/// use `take_until("foo")`.
+///
 /// # Simple Example
 /// ```rust
 /// # #[macro_use] extern crate nom;
@@ -524,6 +534,16 @@ where
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::TakeUntilParserMatches)))`
 /// if the pattern wasn't met
+///
+/// The performance of this parser depends HEAVILY on the inner parser
+/// failing early. For each step on the input, this will run the inner
+/// parser against the remaining input, so if the inner parser does
+/// not fail fast then you will end up re-parsing the remaining input
+/// repeatedly.
+///
+/// If you are looking to match until a string
+/// (`take_until_parser_matches_and_consume(tag("foo"))`) it would be faster to
+/// use `terminated(take_until("foo"), tag("foo"))`.
 ///
 /// # Example
 /// ```rust

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -573,14 +573,13 @@ pub fn take_until_parser_matches_and_consume<F, Input, O, Error>(
   mut f: F,
 ) -> impl FnMut(Input) -> IResult<Input, Input, Error>
 where
-  Input: InputTake + InputLength + Clone,
+  Input: InputTake + InputIter + InputLength + Clone,
   F: Parser<Input, O, Error>,
   Error: ParseError<Input>,
 {
   move |input: Input| {
     let i = input.clone();
-    let input_length = i.input_len();
-    for ind in 0..=input_length {
+    for (ind, _) in i.iter_indices() {
       let (remaining, taken) = i.take_split(ind);
       match f.parse(remaining) {
         Err(_) => (),
@@ -588,6 +587,17 @@ where
           let res: IResult<Input, Input, Error> = Ok((inner_remaining, taken));
           return res;
         }
+      }
+    }
+    // Attempt to match one last time past the end of the input. This
+    // allows for 0-length combinators to be used (for example, an eof
+    // combinator).
+    let (remaining, taken) = i.take_split(i.input_len());
+    match f.parse(remaining) {
+      Err(_) => (),
+      Ok((inner_remaining, _parser_result)) => {
+        let res: IResult<Input, Input, Error> = Ok((inner_remaining, taken));
+        return res;
       }
     }
     Err(Err::Error(Error::from_error_kind(

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -474,8 +474,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(("hello, world", ErrorKind::TakeUntilParserMatches))));
-/// assert_eq!(until_eof(""), Err(Err::Error(("", ErrorKind::TakeUntilParserMatches))));
+/// assert_eq!(until_eof("hello, world"), Err(Err::Error(error_position!("hello, world", ErrorKind::TakeUntilParserMatches))));
+/// assert_eq!(until_eof(""), Err(Err::Error(error_position!("", ErrorKind::TakeUntilParserMatches))));
 /// ```
 ///
 /// # Powerful Example
@@ -566,8 +566,8 @@ where
 /// }
 ///
 /// assert_eq!(until_eof("hello, worldeof foobar"), Ok((" foobar", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(("hello, world", ErrorKind::TakeUntilParserMatches))));
-/// assert_eq!(until_eof(""), Err(Err::Error(("", ErrorKind::TakeUntilParserMatches))));
+/// assert_eq!(until_eof("hello, world"), Err(Err::Error(error_position!("hello, world", ErrorKind::TakeUntilParserMatches))));
+/// assert_eq!(until_eof(""), Err(Err::Error(error_position!("", ErrorKind::TakeUntilParserMatches))));
 /// ```
 pub fn take_until_parser_matches_and_consume<F, Input, O, Error>(
   mut f: F,
@@ -900,7 +900,7 @@ mod tests {
       super::take_until_parser_matches(tag("xyz"))("aaaaabbaaaabbbaaa");
     assert_eq!(
       result,
-      Err(Err::Error((
+      Err(Err::Error(error_position!(
         "aaaaabbaaaabbbaaa",
         ErrorKind::TakeUntilParserMatches
       )))
@@ -913,7 +913,7 @@ mod tests {
       super::take_until_parser_matches(tag("xyz"))("aaaaabbaaaabbbaaaxy");
     assert_eq!(
       result,
-      Err(Err::Error((
+      Err(Err::Error(error_position!(
         "aaaaabbaaaabbbaaaxy",
         ErrorKind::TakeUntilParserMatches
       )))

--- a/src/error.rs
+++ b/src/error.rs
@@ -475,7 +475,7 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::Many1Count                => 73,
     ErrorKind::Float                     => 74,
     ErrorKind::Satisfy                   => 75,
-    ErrorKind::TakeUntilParserMatches    => 75,
+    ErrorKind::TakeUntilParserMatches    => 76,
   }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -414,6 +414,7 @@ pub enum ErrorKind {
   Many1Count,
   Float,
   Satisfy,
+  TakeUntilParserMatches,
 }
 
 #[rustfmt::skip]
@@ -474,6 +475,7 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::Many1Count                => 73,
     ErrorKind::Float                     => 74,
     ErrorKind::Satisfy                   => 75,
+    ErrorKind::TakeUntilParserMatches    => 75,
   }
 }
 
@@ -536,6 +538,7 @@ impl ErrorKind {
       ErrorKind::Many1Count                => "Count occurrence of >=1 patterns",
       ErrorKind::Float                     => "Float",
       ErrorKind::Satisfy                   => "Satisfy",
+      ErrorKind::TakeUntilParserMatches    => "Take until parser matches",
     }
   }
 }


### PR DESCRIPTION
Implement a macro that will consume input until the child parser matches