### PR TITLE
[WIP] Feature multi range

### DIFF
--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -9,7 +9,7 @@ use nom::{
   branch::alt,
   character::complete::{char, digit1, one_of, space0},
   combinator::map_res,
-  multi::fold_many0,
+  multi::fold,
   sequence::{delimited, pair},
   IResult,
 };
@@ -37,7 +37,7 @@ fn factor(input: &[u8]) -> IResult<&[u8], i64> {
 // the math by folding everything
 fn term(input: &[u8]) -> IResult<&[u8], i64> {
   let (input, init) = factor(input)?;
-  fold_many0(
+  fold(0..,
     pair(one_of("*/"), factor),
     move || init,
     |acc, (op, val)| {
@@ -52,7 +52,7 @@ fn term(input: &[u8]) -> IResult<&[u8], i64> {
 
 fn expr(input: &[u8]) -> IResult<&[u8], i64> {
   let (input, init) = term(input)?;
-  fold_many0(
+  fold(0..,
     pair(one_of("+-"), term),
     move || init,
     |acc, (op, val)| {

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -4,7 +4,7 @@
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use criterion::*;
-use nom::{IResult, bytes::complete::{tag, take_while1}, character::complete::{line_ending, char}, multi::many1};
+use nom::{IResult, bytes::complete::{tag, take_while1}, character::complete::{line_ending, char}, multi::many};
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
 #[derive(Debug)]
@@ -96,14 +96,14 @@ fn message_header_value(input: &[u8]) -> IResult<&[u8], &[u8]> {
 fn message_header(input: &[u8]) -> IResult<&[u8], Header<'_>> {
   let (input, name) = take_while1(is_token)(input)?;
   let (input, _) = char(':')(input)?;
-  let (input, value) = many1(message_header_value)(input)?;
+  let (input, value) = many(1.., message_header_value)(input)?;
 
   Ok((input, Header{ name, value }))
 }
 
 fn request(input: &[u8]) -> IResult<&[u8], (Request<'_>, Vec<Header<'_>>)> {
   let (input, req) = request_line(input)?;
-  let (input, h) = many1(message_header)(input)?;
+  let (input, h) = many(1.., message_header)(input)?;
   let (input, _) = line_ending(input)?;
 
   Ok((input, (req, h)))

--- a/benches/ini.rs
+++ b/benches/ini.rs
@@ -9,7 +9,7 @@ use nom::{
     alphanumeric1 as alphanumeric, char, multispace1 as multispace, space1 as space,
   },
   combinator::{map, map_res, opt},
-  multi::many0,
+  multi::many,
   sequence::{delimited, pair, separated_pair, terminated, tuple},
   IResult,
 };
@@ -33,11 +33,11 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 
 fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
   map(
-    many0(separated_pair(
+    many(0.., separated_pair(
       category,
       opt(multispace),
       map(
-        many0(terminated(key_value, opt(multispace))),
+        many(0.., terminated(key_value, opt(multispace))),
         |vec: Vec<_>| vec.into_iter().collect(),
       ),
     )),
@@ -70,7 +70,7 @@ file=payroll.dat
 \0";
 
   fn acc(i: &[u8]) -> IResult<&[u8], Vec<(&str, &str)>> {
-    many0(key_value)(i)
+    many(0.., key_value)(i)
   }
 
   let mut group = c.benchmark_group("ini keys and values");

--- a/benches/ini_str.rs
+++ b/benches/ini_str.rs
@@ -7,7 +7,7 @@ use nom::{
   bytes::complete::{is_a, tag, take_till, take_while},
   character::complete::{alphanumeric1 as alphanumeric, char, not_line_ending, space0 as space},
   combinator::opt,
-  multi::many0,
+  multi::many,
   sequence::{delimited, pair, terminated, tuple},
   IResult,
 };
@@ -40,7 +40,7 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
 }
 
 fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
-  many0(key_value)(i)
+  many(0.., key_value)(i)
 }
 
 fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
@@ -55,7 +55,7 @@ fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
 }
 
 fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
-  many0(category_and_keys)(i)
+  many(0.., category_and_keys)(i)
 }
 
 fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {

--- a/benches/json.rs
+++ b/benches/json.rs
@@ -11,7 +11,7 @@ use nom::{
   character::complete::{anychar, char, multispace0, none_of},
   combinator::{map, map_opt, map_res, value, verify},
   error::{ErrorKind, ParseError},
-  multi::{fold_many0, separated_list0},
+  multi::{fold, separated_list0},
   number::complete::{double, recognize_float},
   sequence::{delimited, preceded, separated_pair},
   IResult, Parser,
@@ -87,7 +87,7 @@ fn character(input: &str) -> IResult<&str, char> {
 fn string(input: &str) -> IResult<&str, String> {
   delimited(
     char('"'),
-    fold_many0(character, String::new, |mut string, c| {
+    fold(0.., character, String::new, |mut string, c| {
       string.push(c);
       string
     }),

--- a/examples/s_expression.rs
+++ b/examples/s_expression.rs
@@ -13,7 +13,7 @@ use nom::{
   character::complete::{alpha1, char, digit1, multispace0, multispace1, one_of},
   combinator::{cut, map, map_res, opt},
   error::{context, VerboseError},
-  multi::many0,
+  multi::many,
   sequence::{delimited, preceded, terminated, tuple},
   IResult, Parser,
 };
@@ -176,7 +176,7 @@ where
 /// `tuple` is used to sequence parsers together, so we can translate this directly
 /// and then map over it to transform the output into an `Expr::Application`
 fn parse_application<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> {
-  let application_inner = map(tuple((parse_expr, many0(parse_expr))), |(head, tail)| {
+  let application_inner = map(tuple((parse_expr, many(0.., parse_expr))), |(head, tail)| {
     Expr::Application(Box::new(head), tail)
   });
   // finally, we wrap it in an s-expression
@@ -226,7 +226,7 @@ fn parse_quote<'a>(i: &'a str) -> IResult<&'a str, Expr, VerboseError<&'a str>> 
   // we find the `'` (quote) character, use cut to say that we're unambiguously
   // looking for an s-expression of 0 or more expressions, and then parse them
   map(
-    context("quote", preceded(tag("'"), cut(s_exp(many0(parse_expr))))),
+    context("quote", preceded(tag("'"), cut(s_exp(many(0.., parse_expr))))),
     |exprs| Expr::Quote(exprs),
   )(i)
 }

--- a/examples/string.rs
+++ b/examples/string.rs
@@ -19,7 +19,7 @@ use nom::bytes::streaming::{is_not, take_while_m_n};
 use nom::character::streaming::{char, multispace1};
 use nom::combinator::{map, map_opt, map_res, value, verify};
 use nom::error::{FromExternalError, ParseError};
-use nom::multi::fold_many0;
+use nom::multi::fold;
 use nom::sequence::{delimited, preceded};
 use nom::IResult;
 
@@ -139,9 +139,10 @@ fn parse_string<'a, E>(input: &'a str) -> IResult<&'a str, String, E>
 where
   E: ParseError<&'a str> + FromExternalError<&'a str, std::num::ParseIntError>,
 {
-  // fold_many0 is the equivalent of iterator::fold. It runs a parser in a loop,
+  // fold is the equivalent of iterator::fold. It runs a parser in a loop,
   // and for each output value, calls a folding function on each output value.
-  let build_string = fold_many0(
+  let build_string = fold(
+    0..,
     // Our parser function– parses a single string fragment
     parse_fragment,
     // Our init value, an empty string
@@ -160,7 +161,7 @@ where
 
   // Finally, parse the string. Note that, if `build_string` could accept a raw
   // " character, the closing delimiter " would never match. When using
-  // `delimited` with a looping parser (like fold_many0), be sure that the
+  // `delimited` with a looping parser (like fold), be sure that the
   // loop won't accidentally match your closing delimiter!
   delimited(char('"'), build_string, char('"'))(input)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -417,6 +417,8 @@ pub enum ErrorKind {
   Float,
   Satisfy,
   Fail,
+  Many,
+  Fold,
 }
 
 #[rustfmt::skip]
@@ -477,6 +479,8 @@ pub fn error_to_u32(e: &ErrorKind) -> u32 {
     ErrorKind::Float                     => 73,
     ErrorKind::Satisfy                   => 74,
     ErrorKind::Fail                      => 75,
+    ErrorKind::Many                      => 76,
+    ErrorKind::Fold                      => 77,
   }
 }
 
@@ -539,6 +543,8 @@ impl ErrorKind {
       ErrorKind::Float                     => "Float",
       ErrorKind::Satisfy                   => "Satisfy",
       ErrorKind::Fail                      => "Fail",
+      ErrorKind::Many                      => "Many",
+      ErrorKind::Fold                      => "Fold",
     }
   }
 }

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -38,6 +38,7 @@ use core::ops::{RangeBounds, Bound};
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
+#[deprecated = "Replaced with `many`"]
 pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + InputLength,
@@ -93,6 +94,7 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
+#[deprecated = "Replaced with `many`"]
 pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + InputLength,
@@ -350,6 +352,7 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
+#[deprecated = "Replaced with `many`"]
 pub fn many_m_n<I, O, E, F>(
   min: usize,
   max: usize,
@@ -638,6 +641,7 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
+#[deprecated = "Replaced with `fold`"]
 pub fn fold_many0<I, O, E, F, G, H, R>(
   mut f: F,
   mut init: H,
@@ -709,6 +713,7 @@ where
 /// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1))));
 /// ```
+#[deprecated = "Replaced with `fold`"]
 pub fn fold_many1<I, O, E, F, G, H, R>(
   mut f: F,
   mut init: H,
@@ -793,6 +798,7 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
+#[deprecated = "Replaced with `fold`"]
 pub fn fold_many_m_n<I, O, E, F, G, H, R>(
   min: usize,
   max: usize,

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1162,7 +1162,7 @@ where
 
     let mut acc = init();
     
-    for count in range.saturating_iter() {
+    for count in range.saturating_iter().map(|x| x - 1) {
       let len = input.input_len();
       match parse.parse(input.clone()) {
         Ok((tail, value)) => {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1125,7 +1125,7 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
-pub fn fold_many<I, O, E, F, G, H, J, K, R>(
+pub fn fold<I, O, E, F, G, H, J, K, R>(
   range: J,
   mut parse: F,
   mut init: H,

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -10,6 +10,7 @@ use crate::internal::{Err, IResult, Needed, Parser};
 use crate::lib::std::vec::Vec;
 use crate::{NomRange, traits::{InputLength, InputTake, ToUsize}};
 use core::num::NonZeroUsize;
+#[cfg(feature="alloc")]
 use core::ops::Bound;
 
 /// Repeats the embedded parser until it fails

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1048,7 +1048,7 @@ where
     };
     
     let mut res = crate::lib::std::vec::Vec::with_capacity(capacity.unwrap_or(0));
-    for count in range.bounded_iter().map(|x| x - 1) {
+    for count in range.bounded_iter() {
       let len = input.input_len();
       match parse.parse(input.clone()) {
         Ok((tail, value)) => {
@@ -1136,7 +1136,7 @@ where
 
     let mut acc = init();
     
-    for count in range.saturating_iter().map(|x| x - 1) {
+    for count in range.saturating_iter() {
       let len = input.input_len();
       match parse.parse(input.clone()) {
         Ok((tail, value)) => {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -8,7 +8,7 @@ use crate::error::ParseError;
 use crate::internal::{Err, IResult, Needed, Parser};
 #[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
-use crate::traits::{InputLength, InputTake, ToUsize};
+use crate::traits::{InputLength, InputTake, ToUsize, IntoRangeBounds};
 use core::num::NonZeroUsize;
 use core::ops::{RangeBounds, Bound};
 
@@ -1179,24 +1179,4 @@ where
 
     Ok((input, acc))
   }
-}
-
-/// Allows conversion of a type into a RangeBound.
-pub trait IntoRangeBounds<T>
-where
-  T: RangeBounds<usize>
-{
-  /// Convert to a RangeBound
-  fn convert(self) -> T;
-}
-
-impl<T> IntoRangeBounds<T> for T
-where
-  T: RangeBounds<usize>
-{
-  fn convert(self) -> T {self}
-}
-
-impl IntoRangeBounds<std::ops::RangeInclusive<usize>> for usize {
-  fn convert(self) -> std::ops::RangeInclusive<usize> {self..=self}
 }

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1003,7 +1003,8 @@ where
 /// Fails if the amount of time the embedded parser is run is not
 /// within the specified range.
 /// # Arguments
-/// * `range` The amount of times to apply the parser.
+/// * `range` The amount of times to apply the parser. A range without
+/// an upper bound is the same as `(lower..=usize::MAX)`.
 /// * `parse` The parser to apply.
 /// ```rust
 /// # #[macro_use] extern crate nom;
@@ -1119,7 +1120,8 @@ where
 /// within the specified range.
 /// 
 /// # Arguments
-/// * `range` The amount of times to apply the parser.
+/// * `range` The amount of times to apply the parser. A range without
+/// an upper bound means the parser can run infinitely.
 /// * `parse` The parser to apply.
 /// * `init` A function returning the initial value.
 /// * `fold` The function that combines a result of `f` with

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1003,9 +1003,9 @@ where
 /// Fails if the amount of time the embedded parser is run is not
 /// within the specified range.
 /// # Arguments
-/// * `range` The amount of times to apply the parser.
-///   * A range with an upper bound `a..=b` limits the parser to run at most `b` times.
+/// * `range` Constrains the number of iterations.
 ///   * A range without an upper bound `a..` is equivalent to a range of `a..=usize::MAX`.
+///   * A single `usize` value is equivalent to `value..=value`.
 ///   * An empty range is invalid.
 /// * `parse` The parser to apply.
 /// ```rust
@@ -1042,12 +1042,12 @@ where
     }
     
     let capacity = match range.bounds() {
-      (Bound::Included(start), _) => Some(start),
-      (Bound::Excluded(start), _) => Some(start + 1),
-      _ => None,
+      (Bound::Included(start), _) => start,
+      (Bound::Excluded(start), _) => start + 1,
+      _ => 4,
     };
     
-    let mut res = crate::lib::std::vec::Vec::with_capacity(capacity.unwrap_or(0));
+    let mut res = crate::lib::std::vec::Vec::with_capacity(capacity);
     for count in range.bounded_iter() {
       let len = input.input_len();
       match parse.parse(input.clone()) {
@@ -1083,9 +1083,9 @@ where
 /// within the specified range.
 /// 
 /// # Arguments
-/// * `range` The amount of times to apply the parser.
-///   * A range with an upper bound `a..=b` limits the parser to run at most `b` times.
+/// * `range` Constrains the number of iterations.
 ///   * A range without an upper bound `a..` allows the parser to run until it fails.
+///   * A single `usize` value is equivalent to `value..=value`.
 ///   * An empty range is invalid.
 /// * `parse` The parser to apply.
 /// * `init` A function returning the initial value.

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1048,7 +1048,7 @@ where
 
     let mut res = crate::lib::std::vec::Vec::with_capacity(start.unwrap_or(0));
     
-    for count in range.saturating_iter() {
+    for count in range.bounded_iter() {
       let len = input.input_len();
       match parse.parse(input.clone()) {
         Ok((tail, value)) => {
@@ -1138,7 +1138,7 @@ where
 
     let mut acc = init();
     
-    for count in range.unbounded_iter() {
+    for count in range.saturating_iter() {
       let len = input.input_len();
       match parse.parse(input.clone()) {
         Ok((tail, value)) => {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1003,8 +1003,10 @@ where
 /// Fails if the amount of time the embedded parser is run is not
 /// within the specified range.
 /// # Arguments
-/// * `range` The amount of times to apply the parser. A range without
-/// an upper bound is the same as `(lower..=usize::MAX)`.
+/// * `range` The amount of times to apply the parser.
+///   * A range with an upper bound `a..=b` limits the parser to run at most `b` times.
+///   * A range without an upper bound `a..` is equivalent to a range of `a..=usize::MAX`.
+///   * An empty range is invalid.
 /// * `parse` The parser to apply.
 /// ```rust
 /// # #[macro_use] extern crate nom;
@@ -1083,8 +1085,10 @@ where
 /// within the specified range.
 /// 
 /// # Arguments
-/// * `range` The amount of times to apply the parser. A range without
-/// an upper bound means the parser can run infinitely.
+/// * `range` The amount of times to apply the parser.
+///   * A range with an upper bound `a..=b` limits the parser to run at most `b` times.
+///   * A range without an upper bound `a..` allows the parser to run until it fails.
+///   * An empty range is invalid.
 /// * `parse` The parser to apply.
 /// * `init` A function returning the initial value.
 /// * `fold` The function that combines a result of `f` with

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1026,7 +1026,7 @@ where
   F: Parser<I, O, E>,
   E: ParseError<I>,
   G: IntoRangeBounds<H>,
-  H: RangeBounds<usize>
+  H: RangeBounds<usize>,
 {
   let range = range.convert();
   move |mut input: I| {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -993,7 +993,12 @@ where
   }
 }
 
-/// Range many
+/// Repeats the embedded parser and returns the results in a `Vec`.
+/// Fails if the amount of time the embedded parser is run is not
+/// within the specified range.
+/// # Arguments
+/// * `range` The amount of times to apply the parser.
+/// * `parse` The parser to apply.
 /// ```rust
 /// # #[macro_use] extern crate nom;
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
@@ -1079,7 +1084,17 @@ where
   }
 }
 
-/// Range fold
+/// Applies a parser and accumulates the results using a given
+/// function and initial value.
+/// Fails if the amount of time the embedded parser is run is not
+/// within the specified range.
+/// 
+/// # Arguments
+/// * `range` The amount of times to apply the parser.
+/// * `parse` The parser to apply.
+/// * `init` A function returning the initial value.
+/// * `fold` The function that combines a result of `f` with
+///       the current accumulator.
 /// ```rust
 /// # #[macro_use] extern crate nom;
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
@@ -1166,12 +1181,12 @@ where
   }
 }
 
-///
+/// Allows conversion of a type into a RangeBound.
 pub trait IntoRangeBounds<T>
 where
   T: RangeBounds<usize>
 {
-  ///
+  /// Convert to a RangeBound
   fn convert(self) -> T;
 }
 

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -39,7 +39,6 @@ use core::ops::Bound;
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-#[deprecated = "Replaced with `many`"]
 pub fn many0<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + InputLength,
@@ -95,7 +94,6 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-#[deprecated = "Replaced with `many`"]
 pub fn many1<I, O, E, F>(mut f: F) -> impl FnMut(I) -> IResult<I, Vec<O>, E>
 where
   I: Clone + InputLength,
@@ -353,7 +351,6 @@ where
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
-#[deprecated = "Replaced with `many`"]
 pub fn many_m_n<I, O, E, F>(
   min: usize,
   max: usize,
@@ -642,7 +639,6 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// ```
-#[deprecated = "Replaced with `fold`"]
 pub fn fold_many0<I, O, E, F, G, H, R>(
   mut f: F,
   mut init: H,
@@ -714,7 +710,6 @@ where
 /// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1))));
 /// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1))));
 /// ```
-#[deprecated = "Replaced with `fold`"]
 pub fn fold_many1<I, O, E, F, G, H, R>(
   mut f: F,
   mut init: H,
@@ -799,7 +794,6 @@ where
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
-#[deprecated = "Replaced with `fold`"]
 pub fn fold_many_m_n<I, O, E, F, G, H, R>(
   min: usize,
   max: usize,

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -662,15 +662,15 @@ fn many_test() {
   assert_eq!(multi_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
   assert_eq!(multi_fixed(d), Err(Err::Incomplete(Needed::new(2))));
   
-  fn multi_test(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn multi_never(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many(0..=0, tag("A"))(i)
   }
   
   let a = &b"AA"[..];
   let b = &b"B"[..];
   
-  assert_eq!(multi_test(a), Ok((&b"AA"[..], Vec::new())));
-  assert_eq!(multi_test(b), Ok((&b"B"[..], Vec::new())));
+  assert_eq!(multi_never(a), Ok((&b"AA"[..], Vec::new())));
+  assert_eq!(multi_never(b), Ok((&b"B"[..], Vec::new())));
 }
 
 #[test]
@@ -777,4 +777,14 @@ fn fold_test() {
   assert_eq!(multi_exclusive(a), Ok((&b"AbcdAbcd"[..], res1)));
   let res2 = vec![];
   assert_eq!(multi_exclusive(b), Ok((&b"AAA"[..], res2)));
+  
+  fn fold_never(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0..=0, tag("A"), Vec::new, fold_into_vec)(i)
+  }
+  
+  let a = &b"AAA"[..];
+  let b = &b"B"[..];
+  
+  assert_eq!(fold_never(a), Ok((&b"AA"[..], Vec::new())));
+  assert_eq!(fold_never(b), Ok((&b"B"[..], Vec::new())));
 }

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -9,7 +9,6 @@ use crate::{
   sequence::{pair, tuple},
 };
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 use crate::{
   lib::std::vec::Vec,
   multi::{
@@ -104,7 +103,6 @@ fn separated_list1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 fn many0_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many0(tag("abcd"))(i)
@@ -143,7 +141,6 @@ fn many0_bench(b: &mut Bencher) {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 fn many1_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many1(tag("abcd"))(i)
@@ -192,7 +189,6 @@ fn many_till_test() {
 
 #[test]
 #[cfg(feature = "std")]
-#[allow(deprecated)]
 fn infinite_many() {
   fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
     Err(Err::Error(error_position!(input, ErrorKind::Tag)))
@@ -217,7 +213,6 @@ fn infinite_many() {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 fn many_m_n_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many_m_n(2, 4, tag("Abcd"))(i)
@@ -420,7 +415,6 @@ fn length_value_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 fn fold_many0_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);
@@ -453,7 +447,6 @@ fn fold_many0_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 fn fold_many1_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);
@@ -481,7 +474,6 @@ fn fold_many1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
 fn fold_many_m_n_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -9,6 +9,7 @@ use crate::{
   sequence::{pair, tuple},
 };
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 use crate::{
   lib::std::vec::Vec,
   multi::{
@@ -103,6 +104,7 @@ fn separated_list1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 fn many0_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many0(tag("abcd"))(i)
@@ -141,6 +143,7 @@ fn many0_bench(b: &mut Bencher) {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 fn many1_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many1(tag("abcd"))(i)
@@ -189,6 +192,7 @@ fn many_till_test() {
 
 #[test]
 #[cfg(feature = "std")]
+#[allow(deprecated)]
 fn infinite_many() {
   fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
     println!("input: {:?}", input);
@@ -214,6 +218,7 @@ fn infinite_many() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 fn many_m_n_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many_m_n(2, 4, tag("Abcd"))(i)
@@ -416,6 +421,7 @@ fn length_value_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 fn fold_many0_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);
@@ -448,6 +454,7 @@ fn fold_many0_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 fn fold_many1_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);
@@ -475,6 +482,7 @@ fn fold_many1_test() {
 
 #[test]
 #[cfg(feature = "alloc")]
+#[allow(deprecated)]
 fn fold_many_m_n_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -634,6 +634,27 @@ fn many_test() {
   let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
   assert_eq!(multi_m_n(d), Ok((&b"Abcdefgh"[..], res3)));
   assert_eq!(multi_m_n(e), Err(Err::Incomplete(Needed::new(2))));
+  
+  
+  fn multi_fixed(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    many(2, tag("Abcd"))(i)
+  }
+  
+  let a = &b"Abcdef"[..];
+  let b = &b"AbcdAbcdefgh"[..];
+  let c = &b"AbcdAbcdAbcdAbcdefgh"[..];
+  let d = &b"AbcdAb"[..];
+  
+  assert_eq!(
+    multi_fixed(a),
+    Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
+  );
+  
+  let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(multi_fixed(b), Ok((&b"efgh"[..], res1)));
+  let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(multi_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
+  assert_eq!(multi_fixed(d), Err(Err::Incomplete(Needed::new(2))));
 }
 
 #[test]
@@ -708,4 +729,24 @@ fn fold_test() {
   let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
   assert_eq!(multi_m_n(d), Ok((&b"Abcdefgh"[..], res3)));
   assert_eq!(multi_m_n(e), Err(Err::Incomplete(Needed::new(2))));
+  
+  fn multi_fixed(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(2, tag("Abcd"), Vec::new, fold_into_vec)(i)
+  }
+  
+  let a = &b"Abcdef"[..];
+  let b = &b"AbcdAbcdefgh"[..];
+  let c = &b"AbcdAbcdAbcdAbcdefgh"[..];
+  let d = &b"AbcdAb"[..];
+  
+  assert_eq!(
+    multi_fixed(a),
+    Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
+  );
+  
+  let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(multi_fixed(b), Ok((&b"efgh"[..], res1)));
+  let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
+  assert_eq!(multi_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
+  assert_eq!(multi_fixed(d), Err(Err::Incomplete(Needed::new(2))));
 }

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -661,6 +661,16 @@ fn many_test() {
   let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
   assert_eq!(multi_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
   assert_eq!(multi_fixed(d), Err(Err::Incomplete(Needed::new(2))));
+  
+  fn multi_test(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    many(0..=0, tag("A"))(i)
+  }
+  
+  let a = &b"AA"[..];
+  let b = &b"B"[..];
+  
+  assert_eq!(multi_test(a), Ok((&b"AA"[..], Vec::new())));
+  assert_eq!(multi_test(b), Ok((&b"B"[..], Vec::new())));
 }
 
 #[test]

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -195,7 +195,6 @@ fn many_till_test() {
 #[allow(deprecated)]
 fn infinite_many() {
   fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    println!("input: {:?}", input);
     Err(Err::Error(error_position!(input, ErrorKind::Tag)))
   }
 
@@ -600,7 +599,6 @@ fn many_test() {
   
   
   fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    println!("input: {:?}", input);
     Err(Err::Error(error_position!(input, ErrorKind::Tag)))
   }
 

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -757,4 +757,15 @@ fn fold_test() {
   let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
   assert_eq!(multi_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
   assert_eq!(multi_fixed(d), Err(Err::Incomplete(Needed::new(2))));
+  
+  fn multi_exclusive(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0..2, tag("Abcd"), Vec::new, fold_into_vec)(i)
+  }
+  
+  let a = &b"AbcdAbcdAbcd"[..];
+  let b = &b"AAA"[..];
+  let res1 = vec![&b"Abcd"[..]];
+  assert_eq!(multi_exclusive(a), Ok((&b"AbcdAbcd"[..], res1)));
+  let res2 = vec![];
+  assert_eq!(multi_exclusive(b), Ok((&b"AAA"[..], res2)));
 }

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -552,7 +552,7 @@ fn many1_count_test() {
 }
 
 #[test]
-#[cfg(feature= "alloc")]
+#[cfg(feature = "alloc")]
 fn many_test() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many(0.., tag("abcd"))(i)
@@ -666,6 +666,7 @@ fn many_test() {
 }
 
 #[test]
+#[cfg(feature = "alloc")]
 fn fold_test() {
   fn fold_into_vec<T>(mut acc: Vec<T>, item: T) -> Vec<T> {
     acc.push(item);

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -684,6 +684,18 @@ fn many_test() {
   assert_eq!(many_fixed(d), Err(Err::Incomplete(Needed::new(2))));
   
   
+  fn multi_exclusive(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    many(0..2, tag("Abcd"))(i)
+  }
+  
+  let a = &b"AbcdAbcdAbcd"[..];
+  let b = &b"AAA"[..];
+  let res1 = vec![&b"Abcd"[..]];
+  assert_eq!(multi_exclusive(a), Ok((&b"AbcdAbcd"[..], res1)));
+  let res2 = vec![];
+  assert_eq!(multi_exclusive(b), Ok((&b"AAA"[..], res2)));
+  
+  
   fn many_never(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many(0..=0, tag("A"))(i)
   }
@@ -701,32 +713,79 @@ fn fold_test() {
     acc.push(item);
     acc
   }
-  fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    fold(0.., tag("abcd"), Vec::new, fold_into_vec)(i)
+  
+  // should not go into an infinite loop
+  fn fold_error_0(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
+      Err(Err::Error(error_position!(input, ErrorKind::Tag)))
+    }
+    fold(0.., tst, Vec::new, fold_into_vec)(i)
   }
-  fn multi_empty(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  
+  let a = &b"abcdef"[..];
+  assert_eq!(fold_error_0(a), Ok((a, Vec::new())));
+  
+  
+  fn fold_error_1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fn tst(input: &[u8]) -> IResult<&[u8], &[u8]> {
+      Err(Err::Error(error_position!(input, ErrorKind::Tag)))
+    }
+    fold(1.., tst, Vec::new, fold_into_vec)(i)
+  }
+  
+  let a = &b"abcdef"[..];
+  assert_eq!(
+    fold_error_1(a),
+    Err(Err::Error(error_position!(a, ErrorKind::Tag)))
+  );
+  
+  
+  fn fold_error(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(0.., tag(""), Vec::new, fold_into_vec)(i)
   }
-
-  assert_eq!(multi(&b"abcdef"[..]), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
+  
+  let a = &b"abcdef"[..];
   assert_eq!(
-    multi(&b"abcdabcdefgh"[..]),
-    Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
-  );
-  assert_eq!(multi(&b"azerty"[..]), Ok((&b"azerty"[..], Vec::new())));
-  assert_eq!(multi(&b"abcdab"[..]), Err(Err::Incomplete(Needed::new(2))));
-  assert_eq!(multi(&b"abcd"[..]), Err(Err::Incomplete(Needed::new(4))));
-  assert_eq!(multi(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
-  assert_eq!(
-    multi_empty(&b"abcdef"[..]),
+    fold_error(a),
     Err(Err::Error(error_position!(
-      &b"abcdef"[..],
+      a,
       ErrorKind::Fold
     )))
   );
   
   
-  fn multi1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn fold_invalid(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(2..=1, tag("a"), Vec::new, fold_into_vec)(i)
+  }
+  
+  let a = &b"a"[..];
+  let b = &b"b"[..];
+  assert_eq!(fold_invalid(a), Err(Err::Failure(error_position!(a, ErrorKind::Fold))));
+  assert_eq!(fold_invalid(b), Err(Err::Failure(error_position!(b, ErrorKind::Fold))));
+  
+  
+  fn fold_any(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(0.., tag("abcd"), Vec::new, fold_into_vec)(i)
+  }
+  
+  let a = &b"abcdef"[..];
+  let b = &b"abcdabcdefgh"[..];
+  let c = &b"azerty"[..];
+  let d = &b"abcdab"[..];
+  let e = &b"abcd"[..];
+  let f = &b""[..];
+  assert_eq!(fold_any(a), Ok((&b"ef"[..], vec![&b"abcd"[..]])));
+  assert_eq!(
+    fold_any(b),
+    Ok((&b"efgh"[..], vec![&b"abcd"[..], &b"abcd"[..]]))
+  );
+  assert_eq!(fold_any(c), Ok((c, Vec::new())));
+  assert_eq!(fold_any(d), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(fold_any(e), Err(Err::Incomplete(Needed::new(4))));
+  assert_eq!(fold_any(f), Err(Err::Incomplete(Needed::new(4))));
+  
+  
+  fn fold_1(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(1.., tag("abcd"), Vec::new, fold_into_vec)(i)
   }
 
@@ -734,19 +793,18 @@ fn fold_test() {
   let b = &b"abcdabcdefgh"[..];
   let c = &b"azerty"[..];
   let d = &b"abcdab"[..];
-
   let res1 = vec![&b"abcd"[..]];
-  assert_eq!(multi1(a), Ok((&b"ef"[..], res1)));
+  assert_eq!(fold_1(a), Ok((&b"ef"[..], res1)));
   let res2 = vec![&b"abcd"[..], &b"abcd"[..]];
-  assert_eq!(multi1(b), Ok((&b"efgh"[..], res2)));
+  assert_eq!(fold_1(b), Ok((&b"efgh"[..], res2)));
   assert_eq!(
-    multi1(c),
+    fold_1(c),
     Err(Err::Error(error_position!(c, ErrorKind::Tag)))
   );
-  assert_eq!(multi1(d), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(fold_1(d), Err(Err::Incomplete(Needed::new(2))));
   
   
-  fn multi_m_n(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  fn fold_m_n(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(2..=4, tag("Abcd"), Vec::new, fold_into_vec)(i)
   }
 
@@ -755,20 +813,20 @@ fn fold_test() {
   let c = &b"AbcdAbcdAbcdAbcdefgh"[..];
   let d = &b"AbcdAbcdAbcdAbcdAbcdefgh"[..];
   let e = &b"AbcdAb"[..];
-
   assert_eq!(
-    multi_m_n(a),
+    fold_m_n(a),
     Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
   );
   let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi_m_n(b), Ok((&b"efgh"[..], res1)));
+  assert_eq!(fold_m_n(b), Ok((&b"efgh"[..], res1)));
   let res2 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi_m_n(c), Ok((&b"efgh"[..], res2)));
+  assert_eq!(fold_m_n(c), Ok((&b"efgh"[..], res2)));
   let res3 = vec![&b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi_m_n(d), Ok((&b"Abcdefgh"[..], res3)));
-  assert_eq!(multi_m_n(e), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(fold_m_n(d), Ok((&b"Abcdefgh"[..], res3)));
+  assert_eq!(fold_m_n(e), Err(Err::Incomplete(Needed::new(2))));
   
-  fn multi_fixed(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  
+  fn fold_fixed(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(2, tag("Abcd"), Vec::new, fold_into_vec)(i)
   }
   
@@ -776,28 +834,28 @@ fn fold_test() {
   let b = &b"AbcdAbcdefgh"[..];
   let c = &b"AbcdAbcdAbcdAbcdefgh"[..];
   let d = &b"AbcdAb"[..];
-  
   assert_eq!(
-    multi_fixed(a),
+    fold_fixed(a),
     Err(Err::Error(error_position!(&b"ef"[..], ErrorKind::Tag)))
   );
-  
   let res1 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi_fixed(b), Ok((&b"efgh"[..], res1)));
+  assert_eq!(fold_fixed(b), Ok((&b"efgh"[..], res1)));
   let res2 = vec![&b"Abcd"[..], &b"Abcd"[..]];
-  assert_eq!(multi_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
-  assert_eq!(multi_fixed(d), Err(Err::Incomplete(Needed::new(2))));
+  assert_eq!(fold_fixed(c), Ok((&b"AbcdAbcdefgh"[..], res2)));
+  assert_eq!(fold_fixed(d), Err(Err::Incomplete(Needed::new(2))));
   
-  fn multi_exclusive(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+  
+  fn fold_exclusive(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(0..2, tag("Abcd"), Vec::new, fold_into_vec)(i)
   }
   
   let a = &b"AbcdAbcdAbcd"[..];
   let b = &b"AAA"[..];
   let res1 = vec![&b"Abcd"[..]];
-  assert_eq!(multi_exclusive(a), Ok((&b"AbcdAbcd"[..], res1)));
+  assert_eq!(fold_exclusive(a), Ok((&b"AbcdAbcd"[..], res1)));
   let res2 = vec![];
-  assert_eq!(multi_exclusive(b), Ok((&b"AAA"[..], res2)));
+  assert_eq!(fold_exclusive(b), Ok((&b"AAA"[..], res2)));
+  
   
   fn fold_never(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(0..=0, tag("A"), Vec::new, fold_into_vec)(i)
@@ -805,7 +863,6 @@ fn fold_test() {
   
   let a = &b"AAA"[..];
   let b = &b"B"[..];
-  
   assert_eq!(fold_never(a), Ok((&b"AAA"[..], Vec::new())));
   assert_eq!(fold_never(b), Ok((&b"B"[..], Vec::new())));
 }

--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -785,6 +785,6 @@ fn fold_test() {
   let a = &b"AAA"[..];
   let b = &b"B"[..];
   
-  assert_eq!(fold_never(a), Ok((&b"AA"[..], Vec::new())));
+  assert_eq!(fold_never(a), Ok((&b"AAA"[..], Vec::new())));
   assert_eq!(fold_never(b), Ok((&b"B"[..], Vec::new())));
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
   #[cfg(feature = "alloc")]
-  use crate::{branch::alt, bytes::complete::tag_no_case, combinator::recognize, multi::many1};
+  use crate::{branch::alt, bytes::complete::tag_no_case, combinator::recognize, multi::many};
   use crate::{
     bytes::complete::{is_a, is_not, tag, take, take_till, take_until},
     error::{self, ErrorKind},
@@ -507,7 +507,7 @@ mod test {
     let b = "ababcd";
 
     fn f(i: &str) -> IResult<&str, &str> {
-      recognize(many1(alt((tag("a"), tag("b")))))(i)
+      recognize(many(1.., alt((tag("a"), tag("b")))))(i)
     }
 
     assert_eq!(f(&a[..]), Ok((&a[6..], &a[..])));

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1496,7 +1496,7 @@ impl Iterator for BoundedIterator {
           }
         }
       },
-      (count, Bound::Unbounded)=> {
+      (_, Bound::Unbounded)=> {
         if old_count == usize::MAX {
           if !self.exhausted {
             self.exhausted = true;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1449,7 +1449,7 @@ impl NomRange<usize> for Range<usize> {
   
   fn contains(&self, item: &usize) -> bool {RangeBounds::contains(self, item)}
   
-  fn is_inverted(&self) -> bool {<Range<usize>>::is_empty(self)}
+  fn is_inverted(&self) -> bool {!(self.start < self.end)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
     if self.end == 0 {
@@ -1476,7 +1476,7 @@ impl NomRange<usize> for RangeInclusive<usize> {
   
   fn contains(&self, item: &usize) -> bool {RangeBounds::contains(self, item)}
   
-  fn is_inverted(&self) -> bool {<RangeInclusive<usize>>::is_empty(self)}
+  fn is_inverted(&self) -> bool {!RangeInclusive::contains(self, self.start())}
   
   fn saturating_iter(&self) -> Self::Iter1 {
     0..*self.end()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1436,8 +1436,8 @@ pub trait NomRange<Idx> {
   
   /// Creates a bounded iterator.
   /// A bounded iterator counts the number of iterations starting from 0 up to the upper bound of this range.
-  /// If the upper bounds is infinite the iterator counts up to the largest representable value of its type and
-  /// returns `None` for all further elements.
+  /// If the upper bounds is infinite the iterator counts up until the amount of iterations has reached the 
+  /// largest representable value of its type and then returns `None` for all further elements.
   fn bounded_iter(&self) -> Self::Iter2;
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1489,7 +1489,7 @@ impl NomRange<usize> for RangeInclusive<usize> {
 
 impl NomRange<usize> for RangeFrom<usize> {
   type Iter1 = SaturatingIterator;
-  type Iter2 = RangeInclusive<usize>;
+  type Iter2 = Range<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Included(self.start), Bound::Unbounded)}
   
@@ -1502,7 +1502,7 @@ impl NomRange<usize> for RangeFrom<usize> {
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=core::usize::MAX-1
+      0..core::usize::MAX
   }
 }
 
@@ -1534,8 +1534,8 @@ impl NomRange<usize> for RangeTo<usize> {
 }
 
 impl NomRange<usize> for RangeToInclusive<usize> {
-  type Iter1 = RangeInclusive<usize>;
-  type Iter2 = RangeInclusive<usize>;
+  type Iter1 = Range<usize>;
+  type Iter2 = Range<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Unbounded, Bound::Included(self.end))}
   
@@ -1544,25 +1544,17 @@ impl NomRange<usize> for RangeToInclusive<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-    if self.end == 0 {
-      1..=0
-    } else {
-      0..=self.end-1
-    }
+    0..self.end
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-    if self.end == 0 {
-      1..=0
-    } else {
-      0..=self.end-1
-    }
+    0..self.end
   }
 }
 
 impl NomRange<usize> for RangeFull {
   type Iter1 = SaturatingIterator;
-  type Iter2 = RangeInclusive<usize>;
+  type Iter2 = Range<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Unbounded, Bound::Unbounded)}
   
@@ -1575,13 +1567,13 @@ impl NomRange<usize> for RangeFull {
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=core::usize::MAX-1
+      0..core::usize::MAX
   }
 }
 
 impl NomRange<usize> for usize {
-  type Iter1 = RangeInclusive<usize>;
-  type Iter2 = RangeInclusive<usize>;
+  type Iter1 = Range<usize>;
+  type Iter2 = Range<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Included(*self), Bound::Included(*self))}
   
@@ -1590,19 +1582,11 @@ impl NomRange<usize> for usize {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-    if *self == 0 {
-      1..=0
-    } else {
-      0..=*self-1
-    }
+    0..*self
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-    if *self == 0 {
-      1..=0
-    } else {
-      0..=*self-1
-    }
+    0..*self
   }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1484,7 +1484,7 @@ impl Iterator for BoundedIterator {
         if count > end {
           None
         } else {
-          if (count == usize::MAX) && !self.exhausted {
+          if (old_count == usize::MAX) && !self.exhausted {
             if !self.exhausted {
               self.exhausted = true;
               Some(old_count)
@@ -1497,7 +1497,7 @@ impl Iterator for BoundedIterator {
         }
       },
       (count, Bound::Unbounded)=> {
-        if count == usize::MAX {
+        if old_count == usize::MAX {
           if !self.exhausted {
             self.exhausted = true;
             Some(old_count)
@@ -1535,7 +1535,7 @@ impl Iterator for SaturatingIterator {
         if count > end {
           None
         } else {
-          if (count == usize::MAX) && !self.exhausted {
+          if (old_count == usize::MAX) && !self.exhausted {
             if !self.exhausted {
               self.exhausted = true;
               Some(old_count)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1448,7 +1448,7 @@ impl NomRange<usize> for Range<usize> {
   
   fn contains(&self, item: &usize) -> bool {RangeBounds::contains(self, item)}
   
-  fn is_inverted(&self) -> bool {Range::is_empty(self)}
+  fn is_inverted(&self) -> bool {<Range<usize>>::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
     1..self.end
@@ -1467,7 +1467,7 @@ impl NomRange<usize> for RangeInclusive<usize> {
   
   fn contains(&self, item: &usize) -> bool {RangeBounds::contains(self, item)}
   
-  fn is_inverted(&self) -> bool {RangeInclusive::is_empty(self)}
+  fn is_inverted(&self) -> bool {<RangeInclusive<usize>>::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
       1..=*self.end()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1493,7 +1493,7 @@ impl NomRange<usize> for RangeFrom<usize> {
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=usize::MAX
+      1..=core::usize::MAX
   }
 }
 
@@ -1550,7 +1550,7 @@ impl NomRange<usize> for RangeFull {
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=usize::MAX
+      1..=core::usize::MAX
   }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1413,8 +1413,8 @@ where
   fn convert(self) -> T {self}
 }
 
-impl IntoRangeBounds<std::ops::RangeInclusive<usize>> for usize {
-  fn convert(self) -> std::ops::RangeInclusive<usize> {self..=self}
+impl IntoRangeBounds<core::ops::RangeInclusive<usize>> for usize {
+  fn convert(self) -> core::ops::RangeInclusive<usize> {self..=self}
 }
 
 /// Allows iteration over ranges. All iterators start at 0 and
@@ -1484,7 +1484,7 @@ impl Iterator for BoundedIterator {
         if count > end {
           None
         } else {
-          if (old_count == usize::MAX) && !self.exhausted {
+          if (old_count == core::usize::MAX) && !self.exhausted {
             if !self.exhausted {
               self.exhausted = true;
               Some(old_count)
@@ -1497,7 +1497,7 @@ impl Iterator for BoundedIterator {
         }
       },
       (_, Bound::Unbounded)=> {
-        if old_count == usize::MAX {
+        if old_count == core::usize::MAX {
           if !self.exhausted {
             self.exhausted = true;
             Some(old_count)
@@ -1535,7 +1535,7 @@ impl Iterator for SaturatingIterator {
         if count > end {
           None
         } else {
-          if (old_count == usize::MAX) && !self.exhausted {
+          if (old_count == core::usize::MAX) && !self.exhausted {
             if !self.exhausted {
               self.exhausted = true;
               Some(old_count)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1429,13 +1429,13 @@ pub trait NomRange<Idx> {
   fn is_inverted(&self) -> bool;
 
   /// Creates a saturating iterator.
-  /// A saturating iterator counts the number of iterations starting from 1 up to the upper bound of this range.
+  /// A saturating iterator counts the number of iterations starting from 0 up to the upper bound of this range.
   /// If the upper bound is infinite the iterator saturates at the largest representable value of its type and
   /// returns it for all further elements.
   fn saturating_iter(&self) -> Self::Iter1;
   
   /// Creates a bounded iterator.
-  /// A bounded iterator counts the number of iterations starting from 1 up to the upper bound of this range.
+  /// A bounded iterator counts the number of iterations starting from 0 up to the upper bound of this range.
   /// If the upper bounds is infinite the iterator counts up to the largest representable value of its type and
   /// returns `None` for all further elements.
   fn bounded_iter(&self) -> Self::Iter2;
@@ -1452,11 +1452,19 @@ impl NomRange<usize> for Range<usize> {
   fn is_inverted(&self) -> bool {<Range<usize>>::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-    1..self.end
+    if self.end == 0 {
+      1..0
+    } else {
+      0..self.end-1
+    }
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-    1..self.end
+    if self.end == 0 {
+      1..0
+    } else {
+      0..self.end-1
+    }
   }
 }
 
@@ -1471,11 +1479,19 @@ impl NomRange<usize> for RangeInclusive<usize> {
   fn is_inverted(&self) -> bool {<RangeInclusive<usize>>::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      1..=*self.end()
+    if *self.end() == 0 {
+      1..=0
+    } else {
+      0..=self.end()-1
+    }
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=*self.end()
+    if *self.end() == 0 {
+      1..=0
+    } else {
+      0..=self.end()-1
+    }
   }
 }
 
@@ -1490,11 +1506,11 @@ impl NomRange<usize> for RangeFrom<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      SaturatingIterator {count: 1}
+      SaturatingIterator {count: 0}
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=core::usize::MAX
+      0..=core::usize::MAX-1
   }
 }
 
@@ -1509,11 +1525,19 @@ impl NomRange<usize> for RangeTo<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      1..self.end
+    if self.end == 0 {
+      1..0
+    } else {
+      0..self.end-1
+    }
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..self.end
+    if self.end == 0 {
+      1..0
+    } else {
+      0..self.end-1
+    }
   }
 }
 
@@ -1528,11 +1552,19 @@ impl NomRange<usize> for RangeToInclusive<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      1..=self.end
+    if self.end == 0 {
+      1..=0
+    } else {
+      0..=self.end-1
+    }
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=self.end
+    if self.end == 0 {
+      1..=0
+    } else {
+      0..=self.end-1
+    }
   }
 }
 
@@ -1547,11 +1579,11 @@ impl NomRange<usize> for RangeFull {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      SaturatingIterator{count: 1}
+      SaturatingIterator{count: 0}
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=core::usize::MAX
+      0..=core::usize::MAX-1
   }
 }
 
@@ -1566,11 +1598,19 @@ impl NomRange<usize> for usize {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      1..=*self
+    if *self == 0 {
+      1..=0
+    } else {
+      0..=*self-1
+    }
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      1..=*self
+    if *self == 0 {
+      1..=0
+    } else {
+      0..=*self-1
+    }
   }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -9,6 +9,8 @@ use crate::lib::std::str::CharIndices;
 use crate::lib::std::str::Chars;
 use crate::lib::std::str::FromStr;
 
+use core::ops::RangeBounds;
+
 #[cfg(feature = "alloc")]
 use crate::lib::std::string::String;
 #[cfg(feature = "alloc")]
@@ -1393,6 +1395,26 @@ impl HexDisplay for str {
   fn to_hex_from(&self, chunk_size: usize, from: usize) -> String {
     self.as_bytes().to_hex_from(chunk_size, from)
   }
+}
+
+/// Allows conversion of a type into a RangeBound.
+pub trait IntoRangeBounds<T>
+where
+  T: RangeBounds<usize>
+{
+  /// Convert to a RangeBound
+  fn convert(self) -> T;
+}
+
+impl<T> IntoRangeBounds<T> for T
+where
+  T: RangeBounds<usize>
+{
+  fn convert(self) -> T {self}
+}
+
+impl IntoRangeBounds<std::ops::RangeInclusive<usize>> for usize {
+  fn convert(self) -> std::ops::RangeInclusive<usize> {self..=self}
 }
 
 #[cfg(test)]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1397,12 +1397,12 @@ impl HexDisplay for str {
   }
 }
 
-///
-pub struct SaturatingIter2 {
+/// A saturating iterator for usize.
+pub struct SaturatingIter {
   count: usize,
 }
 
-impl Iterator for SaturatingIter2 {
+impl Iterator for SaturatingIter {
   type Item = usize;
   
   fn next(&mut self) -> Option<Self::Item> {
@@ -1412,24 +1412,31 @@ impl Iterator for SaturatingIter2 {
   }
 }
 
-/// trait description
+/// Abstractions for range-like types.
 pub trait NomRange<Idx> {
-  ///
+  /// The saturating iterator type.
   type Iter1: Iterator<Item=Idx>;
-  ///
+  /// The bounded iterator type.
   type Iter2: Iterator<Item=Idx>;
   
-  ///
+  /// `true` if `item` is contained in the range.
+  fn contains(&self, item: &Idx) -> bool;
+  
+  /// Returns the bounds of this range.
   fn bounds(&self) -> (Bound<Idx>, Bound<Idx>);
   
-  ///
-  fn contains(&self, item: &Idx) -> bool;
-  ///
+  /// `true` if the range is inverted.
   fn is_inverted(&self) -> bool;
 
-  ///
+  /// Creates a saturating iterator.
+  /// A saturating iterator counts the number of iterations starting from 1 up to the upper bound of this range.
+  /// If the upper bound is infinite the iterator saturates at the largest representable value of its type and
+  /// returns it for all further elements.
   fn saturating_iter(&self) -> Self::Iter1;
-  ///
+  /// Creates a bounded iterator.
+  /// A bounded iterator counts the number of iterations starting from 1 up to the upper bound of this range.
+  /// If the upper bounds is infinite the iterator counts up to the largest representable value of its type and
+  /// returns `None` for all further elements.
   fn bounded_iter(&self) -> Self::Iter2;
 }
 
@@ -1444,11 +1451,11 @@ impl NomRange<usize> for Range<usize> {
   fn is_inverted(&self) -> bool {Range::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-    0..self.end.saturating_sub(1)
+    1..self.end
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-    0..self.end.saturating_sub(1)
+    1..self.end
   }
 }
 
@@ -1463,16 +1470,16 @@ impl NomRange<usize> for RangeInclusive<usize> {
   fn is_inverted(&self) -> bool {RangeInclusive::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      0..=self.end().saturating_sub(1)
+      1..=*self.end()
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=self.end().saturating_sub(1)
+      1..=*self.end()
   }
 }
 
 impl NomRange<usize> for RangeFrom<usize> {
-  type Iter1 = SaturatingIter2;
+  type Iter1 = SaturatingIter;
   type Iter2 = RangeInclusive<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Included(self.start), Bound::Unbounded)}
@@ -1482,11 +1489,11 @@ impl NomRange<usize> for RangeFrom<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      SaturatingIter2 {count: 0}
+      SaturatingIter {count: 1}
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=usize::MAX-1
+      1..=usize::MAX
   }
 }
 
@@ -1501,11 +1508,11 @@ impl NomRange<usize> for RangeTo<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      0..self.end.saturating_sub(1)
+      1..self.end
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..self.end.saturating_sub(1)
+      1..self.end
   }
 }
 
@@ -1520,16 +1527,16 @@ impl NomRange<usize> for RangeToInclusive<usize> {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      0..=self.end.saturating_sub(1)
+      1..=self.end
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=self.end.saturating_sub(1)
+      1..=self.end
   }
 }
 
 impl NomRange<usize> for RangeFull {
-  type Iter1 = SaturatingIter2;
+  type Iter1 = SaturatingIter;
   type Iter2 = RangeInclusive<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Unbounded, Bound::Unbounded)}
@@ -1539,11 +1546,11 @@ impl NomRange<usize> for RangeFull {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      SaturatingIter2{count: 0}
+      SaturatingIter{count: 1}
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=usize::MAX-1
+      1..=usize::MAX
   }
 }
 
@@ -1558,11 +1565,11 @@ impl NomRange<usize> for usize {
   fn is_inverted(&self) -> bool {false}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-      0..=self.saturating_sub(1)
+      1..=*self
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-      0..=self.saturating_sub(1)
+      1..=*self
   }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1469,8 +1469,8 @@ impl NomRange<usize> for Range<usize> {
 }
 
 impl NomRange<usize> for RangeInclusive<usize> {
-  type Iter1 = RangeInclusive<usize>;
-  type Iter2 = RangeInclusive<usize>;
+  type Iter1 = Range<usize>;
+  type Iter2 = Range<usize>;
   
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {(Bound::Included(*self.start()), Bound::Included(*self.end()))}
   
@@ -1479,19 +1479,11 @@ impl NomRange<usize> for RangeInclusive<usize> {
   fn is_inverted(&self) -> bool {<RangeInclusive<usize>>::is_empty(self)}
   
   fn saturating_iter(&self) -> Self::Iter1 {
-    if *self.end() == 0 {
-      1..=0
-    } else {
-      0..=self.end()-1
-    }
+    0..*self.end()
   }
   
   fn bounded_iter(&self) -> Self::Iter2 {
-    if *self.end() == 0 {
-      1..=0
-    } else {
-      0..=self.end()-1
-    }
+    0..*self.end()
   }
 }
 

--- a/tests/arithmetic.rs
+++ b/tests/arithmetic.rs
@@ -4,7 +4,7 @@ use nom::{
   character::complete::char,
   character::complete::{digit1 as digit, space0 as space},
   combinator::map_res,
-  multi::fold_many0,
+  multi::fold,
   sequence::{delimited, pair},
   IResult,
 };
@@ -35,7 +35,8 @@ fn factor(i: &str) -> IResult<&str, i64> {
 fn term(i: &str) -> IResult<&str, i64> {
   let (i, init) = factor(i)?;
 
-  fold_many0(
+  fold(
+    0..,
     pair(alt((char('*'), char('/'))), factor),
     move || init,
     |acc, (op, val): (char, i64)| {
@@ -51,7 +52,8 @@ fn term(i: &str) -> IResult<&str, i64> {
 fn expr(i: &str) -> IResult<&str, i64> {
   let (i, init) = term(i)?;
 
-  fold_many0(
+  fold(
+    0..,
     pair(alt((char('+'), char('-'))), term),
     move || init,
     |acc, (op, val): (char, i64)| {

--- a/tests/arithmetic_ast.rs
+++ b/tests/arithmetic_ast.rs
@@ -8,7 +8,7 @@ use nom::{
   bytes::complete::tag,
   character::complete::{digit1 as digit, multispace0 as multispace},
   combinator::{map, map_res},
-  multi::many0,
+  multi::many,
   sequence::{delimited, preceded},
   IResult,
 };
@@ -90,7 +90,7 @@ fn fold_exprs(initial: Expr, remainder: Vec<(Oper, Expr)>) -> Expr {
 
 fn term(i: &str) -> IResult<&str, Expr> {
   let (i, initial) = factor(i)?;
-  let (i, remainder) = many0(alt((
+  let (i, remainder) = many(0.., alt((
     |i| {
       let (i, mul) = preceded(tag("*"), factor)(i)?;
       Ok((i, (Oper::Mul, mul)))
@@ -106,7 +106,7 @@ fn term(i: &str) -> IResult<&str, Expr> {
 
 fn expr(i: &str) -> IResult<&str, Expr> {
   let (i, initial) = term(i)?;
-  let (i, remainder) = many0(alt((
+  let (i, remainder) = many(0.., alt((
     |i| {
       let (i, add) = preceded(tag("+"), term)(i)?;
       Ok((i, (Oper::Add, add)))

--- a/tests/fnmut.rs
+++ b/tests/fnmut.rs
@@ -8,7 +8,7 @@ fn parse() {
   let mut counter = 0;
 
   let res = {
-    let mut parser = many::<_, _, (), _, _, _>(0.., |i| {
+    let mut parser = many::<_, _, (), _, _>(0.., |i| {
       counter += 1;
       tag("abc")(i)
     });

--- a/tests/fnmut.rs
+++ b/tests/fnmut.rs
@@ -1,6 +1,6 @@
 use nom::{
   bytes::complete::tag,
-  multi::{many0, many0_count},
+  multi::{many, many0_count},
 };
 
 #[test]
@@ -8,7 +8,7 @@ fn parse() {
   let mut counter = 0;
 
   let res = {
-    let mut parser = many0::<_, _, (), _>(|i| {
+    let mut parser = many::<_, _, (), _, _, _>(0.., |i| {
       counter += 1;
       tag("abc")(i)
     });

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -4,7 +4,7 @@ use nom::{
     alphanumeric1 as alphanumeric, char, multispace0 as multispace, space0 as space,
   },
   combinator::{map, map_res, opt},
-  multi::many0,
+  multi::many,
   sequence::{delimited, pair, separated_pair, terminated, tuple},
   IResult,
 };
@@ -28,7 +28,7 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 }
 
 fn keys_and_values(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
-  map(many0(terminated(key_value, opt(multispace))), |vec| {
+  map(many(0.., terminated(key_value, opt(multispace))), |vec| {
     vec.into_iter().collect()
   })(i)
 }
@@ -41,11 +41,11 @@ fn category_and_keys(i: &[u8]) -> IResult<&[u8], (&str, HashMap<&str, &str>)> {
 
 fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
   map(
-    many0(separated_pair(
+    many(0.., separated_pair(
       category,
       opt(multispace),
       map(
-        many0(terminated(key_value, opt(multispace))),
+        many(0.., terminated(key_value, opt(multispace))),
         |vec: Vec<_>| vec.into_iter().collect(),
       ),
     )),

--- a/tests/ini_str.rs
+++ b/tests/ini_str.rs
@@ -2,7 +2,7 @@ use nom::{
   bytes::complete::{is_a, tag, take_till, take_while},
   character::complete::{alphanumeric1 as alphanumeric, char, space0 as space},
   combinator::opt,
-  multi::many0,
+  multi::many,
   sequence::{delimited, pair, terminated, tuple},
   IResult,
 };
@@ -40,7 +40,7 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
 }
 
 fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
-  many0(key_value)(i)
+  many(0.., key_value)(i)
 }
 
 fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
@@ -55,7 +55,7 @@ fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
 }
 
 fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
-  many0(category_and_keys)(i)
+  many(0.., category_and_keys)(i)
 }
 
 fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -24,13 +24,13 @@ mod parse_int {
   use nom::{
     character::streaming::{digit1 as digit, space1 as space},
     combinator::{complete, map, opt},
-    multi::many0,
+    multi::many,
     IResult,
   };
   use std::str;
 
   fn parse_ints(input: &[u8]) -> IResult<&[u8], Vec<i32>> {
-    many0(spaces_or_int)(input)
+    many(0.., spaces_or_int)(input)
   }
 
   fn spaces_or_int(input: &[u8]) -> IResult<&[u8], i32> {
@@ -170,8 +170,8 @@ fn issue_942() {
 #[test]
 fn issue_many_m_n_with_zeros() {
   use nom::character::complete::char;
-  use nom::multi::many_m_n;
-  let mut parser = many_m_n::<_, _, (), _>(0, 0, char('a'));
+  use nom::multi::many;
+  let mut parser = many::<_, _, (), _, _, _>(0..=0, char('a'));
   assert_eq!(parser("aaa"), Ok(("aaa", vec!())));
 }
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -171,7 +171,7 @@ fn issue_942() {
 fn issue_many_m_n_with_zeros() {
   use nom::character::complete::char;
   use nom::multi::many;
-  let mut parser = many::<_, _, (), _, _, _>(0..=0, char('a'));
+  let mut parser = many::<_, _, (), _, _>(0..=0, char('a'));
   assert_eq!(parser("aaa"), Ok(("aaa", vec!())));
 }
 

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -6,7 +6,7 @@ use nom::{
   character::complete::{anychar, char, multispace0, none_of},
   combinator::{map, map_opt, map_res, value, verify},
   error::ParseError,
-  multi::{fold_many0, separated_list0},
+  multi::{fold, separated_list0},
   number::complete::double,
   sequence::{delimited, preceded, separated_pair},
   IResult, Parser,
@@ -82,7 +82,7 @@ fn character(input: &str) -> IResult<&str, char> {
 fn string(input: &str) -> IResult<&str, String> {
   delimited(
     char('"'),
-    fold_many0(character, String::new, |mut string, c| {
+    fold(0.., character, String::new, |mut string, c| {
       string.push(c);
       string
     }),

--- a/tests/mp4.rs
+++ b/tests/mp4.rs
@@ -5,7 +5,7 @@ use nom::{
   bytes::streaming::{tag, take},
   combinator::{map, map_res},
   error::ErrorKind,
-  multi::many0,
+  multi::many,
   number::streaming::{be_f32, be_u16, be_u32, be_u64},
   Err, IResult, Needed,
 };
@@ -250,7 +250,7 @@ fn brand_name(input: &[u8]) -> IResult<&[u8], &str> {
 fn filetype_parser(input: &[u8]) -> IResult<&[u8], FileType<'_>> {
   let (i, name) = brand_name(input)?;
   let (i, version) = take(4_usize)(i)?;
-  let (i, brands) = many0(brand_name)(i)?;
+  let (i, brands) = many(0.., brand_name)(i)?;
 
   let ft = FileType {
     major_brand: name,

--- a/tests/multiline.rs
+++ b/tests/multiline.rs
@@ -1,6 +1,6 @@
 use nom::{
   character::complete::{alphanumeric1 as alphanumeric, line_ending as eol},
-  multi::many0,
+  multi::many,
   sequence::terminated,
   IResult,
 };
@@ -18,7 +18,7 @@ pub fn read_line(input: &str) -> IResult<&str, &str> {
 }
 
 pub fn read_lines(input: &str) -> IResult<&str, Vec<&str>> {
-  many0(read_line)(input)
+  many(0.., read_line)(input)
 }
 
 #[cfg(feature = "alloc")]

--- a/tests/overflow.rs
+++ b/tests/overflow.rs
@@ -3,7 +3,7 @@
 
 use nom::bytes::streaming::take;
 #[cfg(feature = "alloc")]
-use nom::multi::{length_data, many0};
+use nom::multi::{length_data, many};
 #[cfg(feature = "alloc")]
 use nom::number::streaming::be_u64;
 use nom::sequence::tuple;
@@ -28,7 +28,7 @@ fn overflow_incomplete_tuple() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_bytes() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    many0(length_data(be_u64))(i)
+    many(0.., length_data(be_u64))(i)
   }
 
   // Trigger an overflow in length_data
@@ -42,7 +42,7 @@ fn overflow_incomplete_length_bytes() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many0() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    many0(length_data(be_u64))(i)
+    many(0.., length_data(be_u64))(i)
   }
 
   // Trigger an overflow in many0
@@ -55,10 +55,8 @@ fn overflow_incomplete_many0() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many1() {
-  use nom::multi::many1;
-
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    many1(length_data(be_u64))(i)
+    many(1.., length_data(be_u64))(i)
   }
 
   // Trigger an overflow in many1
@@ -87,10 +85,8 @@ fn overflow_incomplete_many_till() {
 #[test]
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_many_m_n() {
-  use nom::multi::many_m_n;
-
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    many_m_n(2, 4, length_data(be_u64))(i)
+    many(2..=4, length_data(be_u64))(i)
   }
 
   // Trigger an overflow in many_m_n
@@ -135,7 +131,7 @@ fn overflow_incomplete_length_count() {
 #[cfg(feature = "alloc")]
 fn overflow_incomplete_length_data() {
   fn multi(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-    many0(length_data(be_u64))(i)
+    many(0.., length_data(be_u64))(i)
   }
 
   assert_eq!(

--- a/tests/reborrow_fold.rs
+++ b/tests/reborrow_fold.rs
@@ -6,7 +6,7 @@ use std::str;
 use nom::bytes::complete::is_not;
 use nom::character::complete::char;
 use nom::combinator::{map, map_res};
-use nom::multi::fold_many0;
+use nom::multi::fold;
 use nom::sequence::delimited;
 use nom::IResult;
 
@@ -23,7 +23,7 @@ fn atom<'a>(_tomb: &'a mut ()) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Stri
 fn list<'a>(i: &'a [u8], tomb: &'a mut ()) -> IResult<&'a [u8], String> {
   delimited(
     char('('),
-    fold_many0(atom(tomb), String::new, |acc: String, next: String| {
+    fold(0.., atom(tomb), String::new, |acc: String, next: String| {
       acc + next.as_str()
     }),
     char(')'),


### PR DESCRIPTION
This PR intends to fix #1393.

### Description
It replaces existing parser variations that only differ by how many times a subparser may run (like the different `many_*` variants) with a single parser that takes a range.

In addition to a range parsers can also take a single `usize` value as parameter which evaluates to a range containing that value only (`value..=value`). This is primarily done for convenience.

Migration remains fairly simple as the new parsers are a full replacement and just require the respective parameters to be rephrased as a single range.

### Reasoning
Using ranges makes the API cleaner by removing unnecessary function duplication. It also allows nom to integrate with more of Rusts language features (specifically the range syntax).

### Example
```rust
many(2..=4,
  tag("Abcd")
)(i)
```
With the old parsers this would be expressed using the `many_m_n` parser:
```rust
many_m_n(2, 4,
  tag("Abcd")
)(i)
```
Special attention should be drawn to the fact that the other variations, such as `many0` are also possible by using open ended ranges (`0..`, `1..`).

### Notes
The current implementation allows individual parsers to take ranges as parameters but requires them to document how they interpret open ended ranges. This was done to maximize flexibility and allow multiple, potentially contradicting, interpretations to coexist within the codebase.

A good example of this in action is the difference between `many` and `fold`:
- `many` (`a..` -> `a..=usize::MAX`)
`many` packages its results into a `Vec`. Therefore going beyond the `usize` limit makes no sense and any open ended range is capped at `usize::MAX`.
- `fold` (`a..`  -> `a..=∞`)
`fold` has static memory requirements since there is only one accumulator. This accumulator can be used indefinitely and as such the amount of iterations can go beyond even the `usize::MAX` limit (the current implementations of `fold_*` also support such cases). Because of this the parser interprets open ended ranges to mean "can run for an infinite number of times".

# TODOs
### Candidates
The following parsers have been proposed for merging.
- [x] `many_*` (many0, many1, many_m_n)
Resolution: Done
- [x] `fold_*` (fold_many0, fold_many1, fold_many_m_n)
Resolution: Done
- [ ] `take_till*` (take_till, take_till1)
- [ ] `take_while*` (take_while, take_while1, take_while_m_n)
- [ ] `take_until*` (take_until, take_until1)
- [ ] `many_till`

### Open questions
- [x] ~~How should the obsolete parsers be handled?
Currently the obsolete parsers (like `many_m_n`) are deprecated using `#[deprecated=""]` with a message pointing the developer to the replacement. (Usually in the form of a simple `Replaced by <new_parser>`). This allows the changes to remain backwards compatible while steering developers towards using the replacement parsers.
Tests for the deprecated parsers are left as is but are annotated with `#[allow(deprecated)]` to suppress the warnings. I would recommend keeping them in for as long as the parsers still exist to make sure that they arent broken accidentally.~~
Resolution: No deprecations for this release. The old parsers and the new range based parsers will exist side-by-side.
- [ ] Resolve open questions of the individual candidates.
See [here](https://github.com/Geal/nom/pull/1402#issuecomment-922387588)