### PR TITLE
Remove reexport of bits::* in crate root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Thanks
 
+### Removed
+
+- `nom::bits::*` is no longer re-exported at the crate root. This export caused frequent confusion, since e.g. `nom::complete::tag` referred to `nom::bits::complete::tag` instead of the much more commonly used `nom::bytes::complete::tag`. To migrate, change any imports of `nom::{complete::*, streaming::*, bits, bytes}` to `nom::bits::[...]`.
+
 ### Changed
 
 ## 7.1.0 - 2021-11-04

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,6 @@ pub mod lib {
   }
 }
 
-pub use self::bits::*;
 pub use self::internal::*;
 pub use self::traits::*;
 


### PR DESCRIPTION
This reexport seems to be a remnant from the days of macro parsers, which no longer exist.

It has caused confusion on several occasions. `nom::complete::tag`, for example, refers to `nom::bits::complete::tag`, while users actually want `nom::bytes::complete::tag` in the vast majority of cases.

This is (obviously) a breaking change and thus needs to wait for v8.0.