### PR TITLE
fix: support empty sep for separated_list0 & separated_list1

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -234,17 +234,16 @@ where
         Err(Err::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
-          // infinite loop check: the parser must always consume
-          if i1.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
-          }
-
           match f.parse(i1.clone()) {
             Err(Err::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
               res.push(o);
               i = i2;
+              // infinite loop check: the parser must always consume
+              if i.input_len() == len {
+                return Err(Err::Error(E::from_error_kind(i, ErrorKind::SeparatedList)));
+              }
             }
           }
         }
@@ -304,17 +303,16 @@ where
         Err(Err::Error(_)) => return Ok((i, res)),
         Err(e) => return Err(e),
         Ok((i1, _)) => {
-          // infinite loop check: the parser must always consume
-          if i1.input_len() == len {
-            return Err(Err::Error(E::from_error_kind(i1, ErrorKind::SeparatedList)));
-          }
-
           match f.parse(i1.clone()) {
             Err(Err::Error(_)) => return Ok((i, res)),
             Err(e) => return Err(e),
             Ok((i2, o)) => {
               res.push(o);
               i = i2;
+              // infinite loop check: the parser must always consume
+              if i.input_len() == len {
+                return Err(Err::Error(E::from_error_kind(i, ErrorKind::SeparatedList)));
+              }
             }
           }
         }


### PR DESCRIPTION
When separator eats nothing(e.g. `opt(tag(","))`), `separated_list0` & `separated_list1` should parse without error. But current implementation returns error when separator eats nothing to prevent infinite loop.
I think the infinite loop check should between loops. If no bytes eaten during the whole loop body, then this will result in infinite loop and should return error.