### PR TITLE
float: Reject invalid exponent instead of failing

### DIFF
--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1414,7 +1414,7 @@ where
       opt(tuple((
         alt((char('e'), char('E'))),
         opt(alt((char('+'), char('-')))),
-        cut(digit1)
+        digit1
       )))
     ))
   )(input)
@@ -2012,10 +2012,7 @@ mod tests {
     }
 
     let remaining_exponent = "-1.234E-";
-    assert_parse!(
-      recognize_float(remaining_exponent),
-      Err(Err::Failure(("", ErrorKind::Digit)))
-    );
+    assert_parse!(recognize_float(remaining_exponent), Ok(("E-", "-1.234")));
 
     let (_i, nan) = float::<_, ()>("NaN").unwrap();
     assert!(nan.is_nan());


### PR DESCRIPTION
Previously, recognize_float() (and by extension various other
float-related functions) returned Err::Failure when encountering an
invalid exponent.

This commit changes the behaviour to rejecting and not consuming the
invalid exponent, but parsing the float before just fine.

Fixes: #1021

<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/main/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
