### PR TITLE
Make `nom::combinator::iterator`'s trait bounds match `impl Iterator for &mut ParserIterator`'s

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -658,7 +658,8 @@ where
 /// ```
 pub fn iterator<Input, Output, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F>
 where
-  F: Parser<Input, Output, Error>,
+  Input: Clone,
+  F: FnMut(Input) -> IResult<Input, Output, Error>,
   Error: ParseError<Input>,
 {
   ParserIterator {


### PR DESCRIPTION
A `ParserIterator`'s primary function is to be an iterator. I'd go so far as to say that a `ParserIterator` that can't function as an iterator is broken.

Currently, `nom::combinator::iterator` expects a `Parser<Input, Output, Error>` for its `f` parameter, but the returned `ParserIterator` object is not actually usable as an iterator unless `f` also conforms to `FnMut(Input) -> IResult<Input, Output, Error>`, because of the constraints on `impl Iterator for &mut ParserIterator`.

In particular, passing in a (type-erased) `impl Parser<Input, Output, Error>` results in an unusable iterator, even if its underlying (unerased) type actually conforms to `FnMut(Input) -> IResult<Input, Output, Error>`.

So, to avoid confusion for callers, let's constrain the `f` parameter to what's _actually_ expected by the `impl Iterator`.

---

### Alternatives

Of course, ideally, the constraints on `impl Iterator for &mut ParserIterator` would be loosened to accept a `Parser<Input, Output, Error>` instead. However, I don't know of any current way to do that without breaking compatibility:

1. The most ideal solution would be to give `Parser` an associated `Output` type. But you can't do that without affecting all callers.
2. Another possibility is to add an `Output` type parameter to `ParserIterator`. But then callers have to be adjusted to specify `ParserIterator` with 4 type parameters instead of 3, so that also breaks compatibility.