### PR TITLE
doc: wording in choosing_a_combinator

### DIFF
--- a/doc/choosing_a_combinator.md
+++ b/doc/choosing_a_combinator.md
@@ -75,11 +75,15 @@ The following parsers could be found on [docs.rs number section](https://docs.rs
 
 ## Modifiers
 
-- [`cond`](https://docs.rs/nom/latest/nom/combinator/fn.cond.html): Conditional combinator. Wraps another parser and calls it if the condition is met
-- [`Parser::flat_map`](https://docs.rs/nom/latest/nom/trait.Parser.html#method.flat_map): method to map a new parser from the output of the first parser, then apply that parser over the rest of the input
-- [`flat_map`](https://docs.rs/nom/latest/nom/combinator/fn.flat_map.html): function variant of `Parser::flat_map`
-- [`Parser::map`](https://docs.rs/nom/latest/nom/trait.Parser.html#method.map): method to map a function on the result of a parser
+
+- [`Parser::and`](https://docs.rs/nom/latest/nom/trait.Parser.html#method.and): method to create a parser by applying the supplied parser to the rest of the input after applying `self`, returning their results as a tuple (like `sequence::tuple` but only takes one parser)
+- [`Parser::and_then`](https://docs.rs/nom/latest/nom/trait.Parser.html#method.and_then): method to create a parser from applying another parser to the output of `self`
+- [`map_parser`](https://docs.rs/nom/latest/nom/combinator/fn.map_parser.html): function variant of `Parser::and_then`
+- [`Parser::map`](https://docs.rs/nom/latest/nom/trait.Parser.html#method.map): method to map a function on the output of `self`
 - [`map`](https://docs.rs/nom/latest/nom/combinator/fn.map.html): function variant of `Parser::map`
+- [`Parser::flat_map`](https://docs.rs/nom/latest/nom/trait.Parser.html#method.flat_map): method to create a parser which will map a parser returning function (such as `take` or something which returns a parser) on the output of `self`, then apply that parser over the rest of the input. That is, this method accepts a parser-returning function which consumes the output of `self`, the resulting parser gets applied to the rest of the input
+- [`flat_map`](https://docs.rs/nom/latest/nom/combinator/fn.flat_map.html): function variant of `Parser::flat_map`
+- [`cond`](https://docs.rs/nom/latest/nom/combinator/fn.cond.html): Conditional combinator. Wraps another parser and calls it if the condition is met
 - [`map_opt`](https://docs.rs/nom/latest/nom/combinator/fn.map_opt.html): Maps a function returning an `Option` on the output of a parser
 - [`map_res`](https://docs.rs/nom/latest/nom/combinator/fn.map_res.html): Maps a function returning a `Result` on the output of a parser
 - [`not`](https://docs.rs/nom/latest/nom/combinator/fn.not.html): Returns a result only if the embedded parser returns `Error` or `Incomplete`. Does not consume the input


### PR DESCRIPTION
I took a stab at introducing some new wording.
- Surfaces `and_then` and its functional variant `map_parser` which I didn't find while first learning Nom.
- Attempts to provide some clarity that I found was lacking around `flat_map`
- Reorders the Modifiers list to try and draw parallels between Trait and Combinator versions.

While I was getting up to speed on Nom, discovering the correct combinator was much harder than discovering a trait function. This was difficult as the example code and explanation usually lives on the combinator. This lead to me using the couple of combinators and base parsers introduced through tutorials and examples, and getting stuck a lot reading this page and things not fitting in the slots like I expected.

Happy for feedback and to change things to fit. If this feels like the right kind of wording, I may go in and update trait function documentation to make things a little friendlier for discovery of the related combinators through intellisense. Also feel free to tell me to go make a blog post instead.

<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/main/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
