### PR TITLE
fix build issues on different rust versions

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -473,7 +473,9 @@ mod tests {
   #[cfg(target_pointer_width = "64")]
   fn size_test() {
     assert_size!(IResult<&[u8], &[u8], (&[u8], u32)>, 40);
-    assert_size!(IResult<&str, &str, u32>, 40);
+    //FIXME: since rust 1.65, this is now 32 bytes, likely thanks to https://github.com/rust-lang/rust/pull/94075
+    // deactivating that test for now because it'll have different values depending on the rust version
+    // assert_size!(IResult<&str, &str, u32>, 40);
     assert_size!(Needed, 8);
     assert_size!(Err<u32>, 16);
     assert_size!(ErrorKind, 1);


### PR DESCRIPTION
* `clamp` is not available in 1.48
* since https://github.com/rust-lang/rust/pull/94075 that shipped in 1.65, a test asserting the size of `IResult` is failing because the structure is now small by 8 bytes