### PR TITLE
switch to edition 2021 and raise MSRV to 1.56.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 
 env:
-  RUST_MINVERSION: 1.42.0
+  RUST_MINVERSION: 1.56.0
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - stable
           - beta
           - nightly
-          - 1.48.0
+          - 1.56.0
 
         features:
           - ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 documentation = "https://docs.rs/nom"
 keywords = ["parser", "parser-combinators", "parsing", "streaming", "bit"]
 categories = ["parsing"]
-edition = "2018"
+edition = "2021"
 autoexamples = false
 
 # also update in README.md (badge and "Rust version requirements" section)
-rust-version = "1.48"
+rust-version = "1.56"
 
 include = [
   "CHANGELOG.md",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://github.com/Geal/nom/actions/workflows/ci.yml/badge.svg)](https://github.com/Geal/nom/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/Geal/nom/badge.svg?branch=main)](https://coveralls.io/github/Geal/nom?branch=main)
 [![Crates.io Version](https://img.shields.io/crates/v/nom.svg)](https://crates.io/crates/nom)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.48.0+-lightgray.svg)](#rust-version-requirements-msrv)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.56.0+-lightgray.svg)](#rust-version-requirements-msrv)
 
 nom is a parser combinators library written in Rust. Its goal is to provide tools
 to build safe parsers without compromising the speed or memory consumption. To
@@ -207,7 +207,7 @@ Some benchmarks are available on [Github](https://github.com/Geal/nom_benchmarks
 
 ## Rust version requirements (MSRV)
 
-The 7.0 series of nom supports **Rustc version 1.48 or greater**. It is known to work properly on Rust 1.41.1 but there is no guarantee it will stay the case through this major release.
+The 7.0 series of nom supports **Rustc version 1.56 or greater**.
 
 The current policy is that this will only be updated in the next major nom release.
 


### PR DESCRIPTION
1.56 supports the rust-version option in Cargo.toml
