### PR TITLE
avoid panic when counting zero-sized outputs in count()

### DIFF
--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -579,7 +579,8 @@ where
 {
   move |i: I| {
     let mut input = i.clone();
-    let max_initial_capacity = MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>().max(1);
+    let max_initial_capacity =
+      MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>().max(1);
     let mut res = crate::lib::std::vec::Vec::with_capacity(count.min(max_initial_capacity));
 
     for _ in 0..count {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -579,7 +579,7 @@ where
 {
   move |i: I| {
     let mut input = i.clone();
-    let max_initial_capacity = MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>();
+    let max_initial_capacity = MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>().max(1);
     let mut res = crate::lib::std::vec::Vec::with_capacity(count.min(max_initial_capacity));
 
     for _ in 0..count {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -242,6 +242,7 @@ fn issue_x_looser_fill_bounds() {
   );
 }
 
+#[test]
 fn issue_1459_clamp_capacity() {
   use nom::character::complete::char;
 
@@ -254,4 +255,15 @@ fn issue_1459_clamp_capacity() {
   use nom::multi::count;
   let mut parser = count::<_, _, (), _>(char('a'), usize::MAX);
   assert_eq!(parser("a"), Err(nom::Err::Error(())));
+}
+
+#[test]
+fn issue_1617_count_parser_returning_zero_size() {
+    use nom::{combinator::map, bytes::complete::tag, error::Error, multi::count};
+
+    // previously, `count()` panicked if the parser had type `O = ()`
+    let parser = map(tag::<_, _, Error<&str>>("abc"), |_| ());
+    // shouldn't panic
+    let result = count(parser, 3)("abcabcabcdef").expect("parsing should succeed");
+    assert_eq!(result, ("def", vec![(), (), ()]));
 }

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -259,11 +259,11 @@ fn issue_1459_clamp_capacity() {
 
 #[test]
 fn issue_1617_count_parser_returning_zero_size() {
-    use nom::{combinator::map, bytes::complete::tag, error::Error, multi::count};
+  use nom::{bytes::complete::tag, combinator::map, error::Error, multi::count};
 
-    // previously, `count()` panicked if the parser had type `O = ()`
-    let parser = map(tag::<_, _, Error<&str>>("abc"), |_| ());
-    // shouldn't panic
-    let result = count(parser, 3)("abcabcabcdef").expect("parsing should succeed");
-    assert_eq!(result, ("def", vec![(), (), ()]));
+  // previously, `count()` panicked if the parser had type `O = ()`
+  let parser = map(tag::<_, _, Error<&str>>("abc"), |_| ());
+  // shouldn't panic
+  let result = count(parser, 3)("abcabcabcdef").expect("parsing should succeed");
+  assert_eq!(result, ("def", vec![(), (), ()]));
 }


### PR DESCRIPTION
## Prerequisites

Resolves #1617.

- Added a test case to `tests/issues.rs`
-  I also annotated an unrelated test-looking function with `#[test]` since it looked like it should be marked as such

## Code style

> This project follows a [code style](https://github.com/Geal/nom/blob/main/rustfmt.toml)
> checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

> Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
> as small as possible increase your chances of getting this merged quickly.

There were a couple of files that were modified by `cargo fmt` that I did not edit, so I undid those changes.