### PR TITLE
make many extend into other collections that Vec

### DIFF
--- a/benchmarks/benches/ini.rs
+++ b/benchmarks/benches/ini.rs
@@ -32,19 +32,16 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 }
 
 fn categories(i: &[u8]) -> IResult<&[u8], HashMap<&str, HashMap<&str, &str>>> {
-  map(
-    many(
-      0..,
-      separated_pair(
-        category,
-        opt(multispace),
-        map(
-          many(0.., terminated(key_value, opt(multispace))),
-          |vec: Vec<_>| vec.into_iter().collect(),
-        ),
+  many(
+    0..,
+    separated_pair(
+      category,
+      opt(multispace),
+      map(
+        many(0.., terminated(key_value, opt(multispace))),
+        |vec: Vec<_>| vec.into_iter().collect(),
       ),
     ),
-    |vec: Vec<_>| vec.into_iter().collect(),
   )(i)
 }
 

--- a/benchmarks/benches/ini_str.rs
+++ b/benchmarks/benches/ini_str.rs
@@ -39,30 +39,16 @@ fn key_value(i: &str) -> IResult<&str, (&str, &str)> {
   Ok((i, (key, val)))
 }
 
-fn keys_and_values_aggregator(i: &str) -> IResult<&str, Vec<(&str, &str)>> {
-  many(0.., key_value)(i)
-}
-
 fn keys_and_values(input: &str) -> IResult<&str, HashMap<&str, &str>> {
-  match keys_and_values_aggregator(input) {
-    Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
-    Err(e) => Err(e),
-  }
+  many(0.., key_value)(input)
 }
 
 fn category_and_keys(i: &str) -> IResult<&str, (&str, HashMap<&str, &str>)> {
   pair(category, keys_and_values)(i)
 }
 
-fn categories_aggregator(i: &str) -> IResult<&str, Vec<(&str, HashMap<&str, &str>)>> {
-  many(0.., category_and_keys)(i)
-}
-
 fn categories(input: &str) -> IResult<&str, HashMap<&str, HashMap<&str, &str>>> {
-  match categories_aggregator(input) {
-    Ok((i, tuple_vec)) => Ok((i, tuple_vec.into_iter().collect())),
-    Err(e) => Err(e),
-  }
+  many(0.., category_and_keys)(input)
 }
 
 fn bench_ini_str(c: &mut Criterion) {

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1079,28 +1079,32 @@ where
 ///
 /// This is not limited to `Vec`:
 ///
-/// /// ```rust
+/// ```rust
 /// # #[macro_use] extern crate nom;
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
 /// use nom::multi::many;
 /// use nom::bytes::complete::{tag, take_while};
-/// use nom::sequence::{separated, terminated};
+/// use nom::sequence::{separated_pair, terminated};
 /// use nom::character::is_alphabetic;
+/// use nom::AsChar;
 ///
-/// use std::collectins::HashMap;
+/// use std::collections::HashMap;
 ///
 /// fn key_value(s: &str) -> IResult<&str, HashMap<&str, &str>> {
 ///   many(0.., terminated(
-///     separated(
-///       take_while(is_alphabetic),
+///     separated_pair(
+///       take_while(AsChar::is_alpha),
 ///       tag("="),
-///       take_while(is_alphabetic)
+///       take_while(AsChar::is_alpha)
 ///     ),
 ///     tag(";")
 ///   ))(s)
 /// }
 ///
-/// assert_eq!(parser("a=b;c=d;"), Ok(("", HashMap::from([("a", "b"), ("c", "d")])));
+/// assert_eq!(
+///   key_value("a=b;c=d;"),
+///   Ok(("", HashMap::from([("a", "b"), ("c", "d")])))
+/// );
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1060,6 +1060,7 @@ where
 ///   * A single `usize` value is equivalent to `value..=value`.
 ///   * An empty range is invalid.
 /// * `parse` The parser to apply.
+///
 /// ```rust
 /// # #[macro_use] extern crate nom;
 /// # use nom::{Err, error::ErrorKind, Needed, IResult};
@@ -1077,7 +1078,8 @@ where
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
 /// ```
 ///
-/// This is not limited to `Vec`:
+/// This is not limited to `Vec`, other collections like `HashMap`
+/// can be used:
 ///
 /// ```rust
 /// # #[macro_use] extern crate nom;
@@ -1085,7 +1087,6 @@ where
 /// use nom::multi::many;
 /// use nom::bytes::complete::{tag, take_while};
 /// use nom::sequence::{separated_pair, terminated};
-/// use nom::character::is_alphabetic;
 /// use nom::AsChar;
 ///
 /// use std::collections::HashMap;
@@ -1105,6 +1106,33 @@ where
 ///   key_value("a=b;c=d;"),
 ///   Ok(("", HashMap::from([("a", "b"), ("c", "d")])))
 /// );
+/// ```
+///
+/// If more control is needed on the default value, [fold] can
+/// be used instead:
+///
+/// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::multi::fold;
+/// use nom::bytes::complete::tag;
+///
+///
+/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+///   fold(
+///     0..=4,
+///     tag("abc"),
+///     // preallocates a vector of the max size
+///     || Vec::with_capacity(4),
+///     |mut acc: Vec<_>, item| {
+///       acc.push(item);
+///       acc
+///     }
+///   )(s)
+/// }
+///
+///
+/// assert_eq!(parser("abcabcabcabc"), Ok(("", vec!["abc", "abc", "abc", "abc"])));
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -1051,7 +1051,7 @@ where
   }
 }
 
-/// Repeats the embedded parser and returns the results in a `Vec`.
+/// Repeats the embedded parser and collects the results in a type implementing `Extend + Default`.
 /// Fails if the amount of time the embedded parser is run is not
 /// within the specified range.
 /// # Arguments
@@ -1075,6 +1075,32 @@ where
 /// assert_eq!(parser("123123"), Ok(("123123", vec![])));
 /// assert_eq!(parser(""), Ok(("", vec![])));
 /// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```
+///
+/// This is not limited to `Vec`:
+///
+/// /// ```rust
+/// # #[macro_use] extern crate nom;
+/// # use nom::{Err, error::ErrorKind, Needed, IResult};
+/// use nom::multi::many;
+/// use nom::bytes::complete::{tag, take_while};
+/// use nom::sequence::{separated, terminated};
+/// use nom::character::is_alphabetic;
+///
+/// use std::collectins::HashMap;
+///
+/// fn key_value(s: &str) -> IResult<&str, HashMap<&str, &str>> {
+///   many(0.., terminated(
+///     separated(
+///       take_while(is_alphabetic),
+///       tag("="),
+///       take_while(is_alphabetic)
+///     ),
+///     tag(";")
+///   ))(s)
+/// }
+///
+/// assert_eq!(parser("a=b;c=d;"), Ok(("", HashMap::from([("a", "b"), ("c", "d")])));
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -8,8 +8,6 @@ use crate::error::ParseError;
 use crate::internal::{Err, IResult, Needed, Parser};
 use crate::lib::std::num::NonZeroUsize;
 #[cfg(feature = "alloc")]
-use crate::lib::std::ops::Bound;
-#[cfg(feature = "alloc")]
 use crate::lib::std::vec::Vec;
 use crate::Input;
 use crate::{
@@ -1091,19 +1089,12 @@ where
   E: ParseError<I>,
   G: NomRange<usize>,
 {
-  /*let capacity = match range.bounds() {
-    (Bound::Included(start), _) => start,
-    (Bound::Excluded(start), _) => start + 1,
-    _ => 4,
-  };*/
-
   move |mut input: I| {
     if range.is_inverted() {
       return Err(Err::Failure(E::from_error_kind(input, ErrorKind::Many)));
     }
 
-    //let max_initial_capacity = MAX_INITIAL_CAPACITY_BYTES / crate::lib::std::mem::size_of::<O>();
-    let mut res = Collection::default(); //crate::lib::std::vec::Vec::with_capacity(capacity.min(max_initial_capacity));
+    let mut res = Collection::default();
 
     for count in range.bounded_iter() {
       let len = input.input_len();

--- a/src/str.rs
+++ b/src/str.rs
@@ -484,7 +484,7 @@ mod test {
     };
   }
 
-  #[test]
+  /*#[test]
   #[cfg(feature = "alloc")]
   fn recognize_is_a() {
     let a = "aabbab";
@@ -496,7 +496,7 @@ mod test {
 
     assert_eq!(f(a), Ok((&a[6..], a)));
     assert_eq!(f(b), Ok((&b[4..], &b[..4])));
-  }
+  }*/
 
   #[test]
   fn utf8_indexing() {

--- a/src/str.rs
+++ b/src/str.rs
@@ -487,6 +487,8 @@ mod test {
   #[test]
   #[cfg(feature = "alloc")]
   fn recognize_is_a() {
+    use crate::lib::std::vec::Vec;
+
     let a = "aabbab";
     let b = "ababcd";
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -484,19 +484,19 @@ mod test {
     };
   }
 
-  /*#[test]
+  #[test]
   #[cfg(feature = "alloc")]
   fn recognize_is_a() {
     let a = "aabbab";
     let b = "ababcd";
 
     fn f(i: &str) -> IResult<&str, &str> {
-      recognize(many(1.., alt((tag("a"), tag("b")))))(i)
+      recognize::<_, Vec<&str>, _, _>(many(1.., alt((tag("a"), tag("b")))))(i)
     }
 
     assert_eq!(f(a), Ok((&a[6..], a)));
     assert_eq!(f(b), Ok((&b[4..], &b[..4])));
-  }*/
+  }
 
   #[test]
   fn utf8_indexing() {

--- a/tests/fnmut.rs
+++ b/tests/fnmut.rs
@@ -8,7 +8,7 @@ fn parse() {
   let mut counter = 0;
 
   let res = {
-    let mut parser = many::<_, _, (), _, _>(0.., |i| {
+    let mut parser = many::<_, _, (), Vec<&str>, _, _>(0.., |i| {
       counter += 1;
       tag("abc")(i)
     });

--- a/tests/ini.rs
+++ b/tests/ini.rs
@@ -28,9 +28,7 @@ fn key_value(i: &[u8]) -> IResult<&[u8], (&str, &str)> {
 }
 
 fn keys_and_values(i: &[u8]) -> IResult<&[u8], HashMap<&str, &str>> {
-  map(many(0.., terminated(key_value, opt(multispace))), |vec| {
-    vec.into_iter().collect()
-  })(i)
+  many(0.., terminated(key_value, opt(multispace)))(i)
 }
 
 fn category_and_keys(i: &[u8]) -> IResult<&[u8], (&str, HashMap<&str, &str>)> {

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -172,7 +172,7 @@ fn issue_942() {
 fn issue_many_m_n_with_zeros() {
   use nom::character::complete::char;
   use nom::multi::many;
-  let mut parser = many::<_, _, (), _, _>(0..=0, char('a'));
+  let mut parser = many::<_, _, (), Vec<char>, _, _>(0..=0, char('a'));
   assert_eq!(parser("aaa"), Ok(("aaa", vec!())));
 }
 


### PR DESCRIPTION
Fix #1409 

This will likely remove the optimizatio of preallocating vector capacity, but we can get this back with a wrapper type if needed, and being able to created directly a hashmap or other collections instead of going through a vec first will be way more useful