### PR TITLE
For `many` and `fold`, consider `..0` an invalid range, just as `0..0` is

### DIFF
--- a/src/multi/tests.rs
+++ b/src/multi/tests.rs
@@ -576,6 +576,7 @@ fn many_test() {
   );
   
   
+  #[allow(clippy::reversed_empty_ranges)]
   fn many_invalid(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     many(2..=1, tag("a"))(i)
   }
@@ -584,6 +585,22 @@ fn many_test() {
   let b = &b"b"[..];
   assert_eq!(many_invalid(a), Err(Err::Failure(error_position!(a, ErrorKind::Many))));
   assert_eq!(many_invalid(b), Err(Err::Failure(error_position!(b, ErrorKind::Many))));
+
+
+  fn many_invalid_range_to(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    many(..0, tag("a"))(i)
+  }
+
+  let a = &b"a"[..];
+  let b = &b"b"[..];
+  assert_eq!(
+    many_invalid_range_to(a),
+    Err(Err::Failure(error_position!(a, ErrorKind::Many)))
+  );
+  assert_eq!(
+    many_invalid_range_to(b),
+    Err(Err::Failure(error_position!(b, ErrorKind::Many)))
+  );
   
   
   fn many_any(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
@@ -737,6 +754,7 @@ fn fold_test() {
   );
   
   
+  #[allow(clippy::reversed_empty_ranges)]
   fn fold_invalid(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
     fold(2..=1, tag("a"), Vec::new, fold_into_vec)(i)
   }
@@ -745,6 +763,22 @@ fn fold_test() {
   let b = &b"b"[..];
   assert_eq!(fold_invalid(a), Err(Err::Failure(error_position!(a, ErrorKind::Fold))));
   assert_eq!(fold_invalid(b), Err(Err::Failure(error_position!(b, ErrorKind::Fold))));
+
+
+  fn fold_invalid_range_to(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+    fold(..0, tag("a"), Vec::new, fold_into_vec)(i)
+  }
+
+  let a = &b"a"[..];
+  let b = &b"b"[..];
+  assert_eq!(
+    fold_invalid_range_to(a),
+    Err(Err::Failure(error_position!(a, ErrorKind::Fold)))
+  );
+  assert_eq!(
+    fold_invalid_range_to(b),
+    Err(Err::Failure(error_position!(b, ErrorKind::Fold)))
+  );
   
   
   fn fold_any(i: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1251,23 +1251,15 @@ impl NomRange<usize> for Range<usize> {
   }
 
   fn is_inverted(&self) -> bool {
-    !(self.start < self.end)
+    self.is_empty()
   }
 
   fn saturating_iter(&self) -> Self::Saturating {
-    if self.end == 0 {
-      1..0
-    } else {
-      0..self.end - 1
-    }
+    0..self.end - 1
   }
 
   fn bounded_iter(&self) -> Self::Bounded {
-    if self.end == 0 {
-      1..0
-    } else {
-      0..self.end - 1
-    }
+    0..self.end - 1
   }
 }
 
@@ -1284,7 +1276,7 @@ impl NomRange<usize> for RangeInclusive<usize> {
   }
 
   fn is_inverted(&self) -> bool {
-    !RangeInclusive::contains(self, self.start())
+    self.is_empty()
   }
 
   fn saturating_iter(&self) -> Self::Saturating {
@@ -1298,7 +1290,7 @@ impl NomRange<usize> for RangeInclusive<usize> {
 
 impl NomRange<usize> for RangeFrom<usize> {
   type Saturating = SaturatingIterator;
-  type Bounded = Range<usize>;
+  type Bounded = RangeInclusive<usize>;
 
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {
     (Bound::Included(self.start), Bound::Unbounded)
@@ -1317,7 +1309,7 @@ impl NomRange<usize> for RangeFrom<usize> {
   }
 
   fn bounded_iter(&self) -> Self::Bounded {
-    0..core::usize::MAX
+    0..=core::usize::MAX
   }
 }
 
@@ -1334,23 +1326,15 @@ impl NomRange<usize> for RangeTo<usize> {
   }
 
   fn is_inverted(&self) -> bool {
-    false
+    self.end == 0
   }
 
   fn saturating_iter(&self) -> Self::Saturating {
-    if self.end == 0 {
-      1..0
-    } else {
-      0..self.end - 1
-    }
+    0..self.end - 1
   }
 
   fn bounded_iter(&self) -> Self::Bounded {
-    if self.end == 0 {
-      1..0
-    } else {
-      0..self.end - 1
-    }
+    0..self.end - 1
   }
 }
 
@@ -1381,7 +1365,7 @@ impl NomRange<usize> for RangeToInclusive<usize> {
 
 impl NomRange<usize> for RangeFull {
   type Saturating = SaturatingIterator;
-  type Bounded = Range<usize>;
+  type Bounded = RangeInclusive<usize>;
 
   fn bounds(&self) -> (Bound<usize>, Bound<usize>) {
     (Bound::Unbounded, Bound::Unbounded)
@@ -1400,7 +1384,7 @@ impl NomRange<usize> for RangeFull {
   }
 
   fn bounded_iter(&self) -> Self::Bounded {
-    0..core::usize::MAX
+    0..=core::usize::MAX
   }
 }
 


### PR DESCRIPTION
`nom::multi::many` and `nom::many::fold` consider empty ranges, as checked by `NomRange::is_inverted`, to be invalid. Unfortunately, that method is incorrectly implemented for `RangeTo`, meaning that `..0` is not considered invalid when it should be.

While I'm here, I also fixed up off-by-one errors in `RangeFrom::bounded_iter` and `RangeFull::bounded_iter`.