### PR TITLE
Enable `Parser`-based `ParserIterator` to work

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -736,18 +736,18 @@ impl<I: Clone, E, F> ParserIterator<I, E, F> {
   }
 }
 
-impl<'a, Input, Output, Error, F> core::iter::Iterator for &'a mut ParserIterator<Input, Error, F>
+impl<'a, Input, F> core::iter::Iterator for &'a mut ParserIterator<Input, F::Error, F>
 where
-  F: FnMut(Input) -> IResult<Input, Output, Error>,
+  F: Parser<Input>,
   Input: Clone,
 {
-  type Item = Output;
+  type Item = F::Output;
 
   fn next(&mut self) -> Option<Self::Item> {
     if let State::Running = self.state.take().unwrap() {
       let input = self.input.clone();
 
-      match (self.iterator)(input) {
+      match self.iterator.parse(input) {
         Ok((i, o)) => {
           self.input = i;
           self.state = Some(State::Running);

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -273,3 +273,15 @@ fn fail_test() {
   assert_eq!(fail::<_, &str, _>(a), Err(Err::Error((a, ErrorKind::Fail))));
   assert_eq!(fail::<_, &str, _>(b), Err(Err::Error((b, ErrorKind::Fail))));
 }
+
+#[test]
+fn test_iterator() {
+  use crate::character::complete::{line_ending, not_line_ending};
+
+  let input = "foo\nbar\r\nbaz";
+  let mut iter = iterator::<_, (), _>(input, (not_line_ending, line_ending));
+  assert_eq!((&mut iter).next(), Some(("foo", "\n")));
+  assert_eq!((&mut iter).next(), Some(("bar", "\r\n")));
+  assert_eq!((&mut iter).next(), None);
+  assert_eq!(iter.finish(), Ok(("baz", ())));
+}


### PR DESCRIPTION
Now that we have associated types for `Parser` (#1626), we can finally make `ParserIterator` support any `Parser`, not just `FnMut(I) -> IResult<I, O, E>`.