### PR TITLE
Update readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,18 @@ error prone plumbing.
 [Hexadecimal color](https://developer.mozilla.org/en-US/docs/Web/CSS/color) parser:
 
 ```rust
-extern crate nom;
 use nom::{
-  IResult,
   bytes::complete::{tag, take_while_m_n},
   combinator::map_res,
-  Parser,
+  sequence::Tuple,
+  IResult,
 };
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct Color {
-  pub red:   u8,
+  pub red: u8,
   pub green: u8,
-  pub blue:  u8,
+  pub blue: u8,
 }
 
 fn from_hex(input: &str) -> Result<u8, std::num::ParseIntError> {
@@ -65,28 +64,32 @@ fn is_hex_digit(c: char) -> bool {
 }
 
 fn hex_primary(input: &str) -> IResult<&str, u8> {
-  map_res(
-    take_while_m_n(2, 2, is_hex_digit),
-    from_hex
-  )(input)
+  map_res(take_while_m_n(2, 2, is_hex_digit), from_hex)(input)
 }
 
 fn hex_color(input: &str) -> IResult<&str, Color> {
   let (input, _) = tag("#")(input)?;
   let (input, (red, green, blue)) = (hex_primary, hex_primary, hex_primary).parse(input)?;
-
   Ok((input, Color { red, green, blue }))
 }
 
-fn main() {}
+fn main() {
+  println!("{:?}", hex_color("#2F14DF"))
+}
 
 #[test]
 fn parse_color() {
-  assert_eq!(hex_color("#2F14DF"), Ok(("", Color {
-    red: 47,
-    green: 20,
-    blue: 223,
-  })));
+  assert_eq!(
+    hex_color("#2F14DF"),
+    Ok((
+      "",
+      Color {
+        red: 47,
+        green: 20,
+        blue: 223,
+      }
+    ))
+  );
 }
 ```
 


### PR DESCRIPTION
This updates the README example to (1) get it to compile and (2) remove some of the unused function warnings. It does this by:
- Importing `sequence::Tuple`
- Adding a `println` to the main function that just outputs the content of the sample parsed hex color

This also adds a few formatting tweaks, these were just the product of formatting the code with `rustfmt`.