### PR TITLE
Change fail output type to unit

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -811,8 +811,8 @@ pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Fn(I) -> IResult<I
 /// use nom::combinator::fail;
 ///
 /// let s = "string";
-/// assert_eq!(fail::<_, &str, _>(s), Err(Err::Error((s, ErrorKind::Fail))));
+/// assert_eq!(fail(s), Err(Err::Error((s, ErrorKind::Fail))));
 /// ```
-pub fn fail<I, O, E: ParseError<I>>(i: I) -> IResult<I, O, E> {
+pub fn fail<I, E: ParseError<I>>(i: I) -> IResult<I, (), E> {
   Err(Err::Error(E::from_error_kind(i, ErrorKind::Fail)))
 }

--- a/src/combinator/tests.rs
+++ b/src/combinator/tests.rs
@@ -270,6 +270,6 @@ fn fail_test() {
   let a = "string";
   let b = "another string";
 
-  assert_eq!(fail::<_, &str, _>(a), Err(Err::Error((a, ErrorKind::Fail))));
-  assert_eq!(fail::<_, &str, _>(b), Err(Err::Error((b, ErrorKind::Fail))));
+  assert_eq!(fail(a), Err(Err::Error((a, ErrorKind::Fail))));
+  assert_eq!(fail(b), Err(Err::Error((b, ErrorKind::Fail))));
 }


### PR DESCRIPTION
<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/Geal/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/Geal/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/Geal/nom/blob/main/rustfmt.toml)
checked by [rustfmt][https://github.com/rust-lang-nursery/rustfmt].

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->

Hello! First of all, thank you for the amazing project. I've been using `nom` for writing a new parser and it's been a joy <3

While working in my project, I noticed that every time I use the `fail` combinator I have to specify the output type despite the parser always failing, hence such type feels irrelevant (?). In this PR I change the output type to `()` and hence simplify the use of the combinator.