### PR TITLE
Fix for trailing semicolon in macros.

### DIFF
--- a/src/branch/macros.rs
+++ b/src/branch/macros.rs
@@ -514,17 +514,17 @@ macro_rules! permutation_init (
   );
 
   (($($parsed:expr),*), $e:ident?, $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*)
   );
   (($($parsed:expr),*), $e:ident, $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*)
   );
 
   (($($parsed:expr),*), $submac:ident!( $($args:tt)* )?, $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*)
   );
   (($($parsed:expr),*), $submac:ident!( $($args:tt)* ), $($rest:tt)*) => (
-    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*);
+    permutation_init!(($($parsed),* , $crate::lib::std::option::Option::None), $($rest)*)
   );
 
   (($($parsed:expr),*), $e:ident) => (

--- a/src/combinator/macros.rs
+++ b/src/combinator/macros.rs
@@ -506,7 +506,7 @@ macro_rules! map(
     map!(__impl $i, $submac!($($args)*), $g);
   );
   ($i:expr, $f:expr, $g:expr) => (
-    map!(__impl $i, call!($f), $g);
+    map!(__impl $i, call!($f), $g)
   );
 );
 


### PR DESCRIPTION
Remove trailing semicolons in expression macro bodies as they will soon not be allowed by the compiler.

See https://github.com/rust-lang/rust/issues/79813 for more information.

We support older releases of Suricata (https://github.com/OISF/suricata) longer than many Rust projects seem to be supported and will be depending on Nom 5.x for some time into the future and would like to prevent a new version of the compiler from breaking builds for our users.

Our hope is that Nom will consider a 5.1.3 release with these changes so we don't have to maintain a fork until our oldest supported release goes end of life.
