### PR TITLE
Use less specific type in custom combinator example

### DIFF
--- a/doc/nom_recipes.md
+++ b/doc/nom_recipes.md
@@ -27,8 +27,8 @@ These are short recipes for accomplishing common tasks with nom.
 ```rust
 use nom::{
   IResult,
+  Parser,
   error::ParseError,
-  combinator::value,
   sequence::delimited,
   character::complete::multispace0,
 };
@@ -37,7 +37,7 @@ use nom::{
 /// trailing whitespace, returning the output of `inner`.
 fn ws<'a, F, O, E: ParseError<&'a str>>(inner: F) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
   where
-  F: FnMut(&'a str) -> IResult<&'a str, O, E>,
+  F: Parser<&'a str, O, E>,
 {
   delimited(
     multispace0,


### PR DESCRIPTION
The custom combinator from the ["Wrapper combinators that eat whitespace before and after a parser"](https://github.com/rust-bakery/nom/blob/1309141ae58265ccbbc330b46233076feb6ff98b/doc/nom_recipes.md#wrapper-combinators-that-eat-whitespace-before-and-after-a-parser) example uses the needlessly specific trait bound `FnMut(...) -> IResult` for its parser parameter type, which limits its applicability as a combinator, because not all parsers (e.g. [`Map`](https://docs.rs/nom/7.1.3/nom/struct.Map.html)) implement the `FnMut(...) -> IResult` trait. But conversely, [`FnMut(...) -> IResult` implements the `Parser` trait](https://docs.rs/nom/7.1.3/nom/trait.Parser.html#impl-Parser%3CI%2C%20O%2C%20E%3E-for-F), so IMHO using [`Parser`](https://docs.rs/nom/7.1.3/nom/trait.Parser.html) as the trait bound instead would make perfect sense.

This PR makes that change and also removes a pointless import of `nom::combinator::value`.

The example in question was the only documentation I could find on how to write a combinator of your own (but to be honest I haven't looked very hard), so that's why I think it's important to get it right.