### PR TITLE
Make is_a example more obvious

### DIFF
--- a/doc/choosing_a_combinator.md
+++ b/doc/choosing_a_combinator.md
@@ -11,7 +11,7 @@ Those are used to recognize the lowest level elements of your grammar, like, "he
 | combinator | usage | input | output | comment |
 |---|---|---|---|---|
 | [char](https://docs.rs/nom/latest/nom/character/complete/fn.char.html) | `char('a')` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one character (works with non ASCII chars too) | 
-| [is_a](https://docs.rs/nom/latest/nom/bytes/complete/fn.is_a.html) | `is_a("ab")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of any of the characters passed as arguments|
+| [is_a](https://docs.rs/nom/latest/nom/bytes/complete/fn.is_a.html) | `is_a("ab")` |  `"abbac"` | `Ok(("c", "abba"))` |Matches a sequence of any of the characters passed as arguments|
 | [is_not](https://docs.rs/nom/latest/nom/bytes/complete/fn.is_not.html) | `is_not("cd")` |  `"ababc"` | `Ok(("c", "abab"))` |Matches a sequence of none of the characters passed as arguments|
 | [one_of](https://docs.rs/nom/latest/nom/character/complete/fn.one_of.html) | `one_of("abc")` |  `"abc"` | `Ok(("bc", 'a'))` |Matches one of the provided characters (works with non ASCII characters too)|
 | [none_of](https://docs.rs/nom/latest/nom/character/complete/fn.none_of.html) | `none_of("abc")` |  `"xyab"` | `Ok(("yab", 'x'))` |Matches anything but the provided characters|


### PR DESCRIPTION
In the ["Choosing a combinator" guide](https://github.com/rust-bakery/nom/blob/1309141ae58265ccbbc330b46233076feb6ff98b/doc/choosing_a_combinator.md), the example for `is_a` is to run `is_a("ab")` on `ababc`, returning `Ok("c", "abab")`. The example by itself (without the accompanying explanation) leaves ambiguous whether the reason `is_a` produced that output was because it parsed `ab` twice (wrong - that's what `tag` is for) or because it parsed `a` or `b` 4 times (correct). IMHO it would be better if, at least for simple functions like that, it was immediately obvious from the examples alone what they do, or at least for the examples to dispel any confusion remaining after reading the explanations. In this case that can be accomplished by just using `abbac` as the example string instead, which this MR does.