### PR TITLE
fix: parse "infinity" literal fully in `float`

### DIFF
--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1283,11 +1283,11 @@ where
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::complete::tag_no_case::<_, _, E>("inf")(i.clone())
+      crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::complete::tag_no_case::<_, _, E>("infinity")(i.clone())
+      crate::bytes::complete::tag_no_case::<_, _, E>("inf")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))
@@ -1853,8 +1853,9 @@ mod tests {
 
     let (_i, inf) = float::<_, ()>("inf").unwrap();
     assert!(inf.is_infinite());
-    let (_i, inf) = float::<_, ()>("infinite").unwrap();
+    let (i, inf) = float::<_, ()>("infinity").unwrap();
     assert!(inf.is_infinite());
+    assert!(i.is_empty());
   }
 
   #[test]

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -1328,11 +1328,11 @@ where
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))
@@ -1448,7 +1448,8 @@ mod tests {
 
     let (_i, inf) = float::<_, ()>("inf").unwrap();
     assert!(inf.is_infinite());
-    let (_i, inf) = float::<_, ()>("infinite").unwrap();
-    assert!(inf.is_infinite());*/
+    let (i, inf) = float::<_, ()>("infinity").unwrap();
+    assert!(inf.is_infinite());
+    assert!(i.is_empty());*/
   }
 }

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1250,11 +1250,11 @@ where
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
     |i: T| {
-      crate::bytes::streaming::tag_no_case::<_, _, E>("infinity")(i.clone())
+      crate::bytes::streaming::tag_no_case::<_, _, E>("inf")(i.clone())
         .map_err(|_| crate::Err::Error(E::from_error_kind(i, ErrorKind::Float)))
     },
   ))
@@ -1928,8 +1928,9 @@ mod tests {
 
     let (_i, inf) = float::<_, ()>("inf").unwrap();
     assert!(inf.is_infinite());
-    let (_i, inf) = float::<_, ()>("infinite").unwrap();
+    let (i, inf) = float::<_, ()>("infinity").unwrap();
     assert!(inf.is_infinite());
+    assert!(i.is_empty());
   }
 
   #[test]


### PR DESCRIPTION
`float` first parsed the "inf" literal and then "infinity", therefore even though the latter was parsed correctly, the suffix "inity" was returned as remaining input, which is not correct.