### PR TITLE
Add `--generate-link-to-definition` option when building on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ proptest = "=1.0.0"
 [package.metadata.docs.rs]
 features = ["alloc", "std", "docsrs"]
 all-features = true
+rustdoc-args = ["--generate-link-to-definition"]
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
This option generates links in source code pages, allowing to jump to definition and to jump back to doc. It makes browsing the source code pages much nicer. You can see it in action [here](https://doc.rust-lang.org/stable/nightly-rustc/src/rustc_middle/lib.rs.html#90).