### PR TITLE
Add eml-codec, imap-codec, smtp-message to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Here is a (non exhaustive) list of known projects using nom:
 
 - Text file formats: [Ceph Crush](https://github.com/cholcombe973/crushtool),
 [Cronenberg](https://github.com/ayrat555/cronenberg),
+[Email](https://github.com/deuxfleurs-org/eml-codec),
 [XFS Runtime Stats](https://github.com/ChrisMacNaughton/xfs-rs),
 [CSV](https://github.com/GuillaumeGomez/csv-parser),
 [FASTA](https://github.com/TianyiShi2001/nom-fasta),
@@ -299,7 +300,7 @@ Here is a (non exhaustive) list of known projects using nom:
 [DHCP](https://github.com/rusticata/dhcp-parser),
 [HTTP](https://github.com/sozu-proxy/sozu/tree/main/lib/src/protocol/http),
 [URI](https://github.com/santifa/rrp/blob/master/src/uri.rs),
-[IMAP](https://github.com/djc/tokio-imap),
+[IMAP](https://github.com/djc/tokio-imap) ([alt](https://github.com/duesee/imap-codec)),
 [IRC](https://github.com/Detegr/RBot-parser),
 [Pcap-NG](https://github.com/richo/pcapng-rs),
 [Pcap](https://github.com/ithinuel/pcap-rs),
@@ -313,6 +314,7 @@ Here is a (non exhaustive) list of known projects using nom:
 [IPFIX / Netflow v10](https://github.com/dominotree/rs-ipfix),
 [GTP](https://github.com/fuerstenau/gorrosion-gtp),
 [SIP](https://github.com/kurotych/sipcore/tree/master/crates/sipmsg),
+[SMTP](https://github.com/Ekleog/kannader),
 [Prometheus](https://github.com/vectordotdev/vector/blob/master/lib/prometheus-parser/src/line.rs)
 - Language specifications:
 [BNF](https://github.com/shnewto/bnf)


### PR DESCRIPTION
From README.md, I read:
> Want to add your parser here? Create a pull request for it!

This PR attempts to add 3 projects using nom:
  - eml-codec, a parser written with nom for Internet Message Format (IMF, RFC5322) and MIME (RFC2045)
  - imap-codec, a parser for the IMAP protocol written by @duesee with nom, that I am using in my projects
  - smtp-message, a parser for the SMTP protocol written by @ekleog written with nom, that I am using in my projects
