### PR TITLE
fuzz: fix fuzz build

### DIFF
--- a/fuzz/fuzz_targets/fuzz_arithmetic.rs
+++ b/fuzz/fuzz_targets/fuzz_arithmetic.rs
@@ -12,66 +12,70 @@ use nom::{
   combinator::{map, map_res, verify},
   multi::fold_many0,
   sequence::{delimited, pair, terminated},
-  IResult,
+  IResult, Parser
 };
 
-use std::str::FromStr;
 use std::cell::RefCell;
+use std::str::FromStr;
 
 thread_local! {
     pub static LEVEL: RefCell<u32> = RefCell::new(0);
 }
 
 fn reset() {
-    LEVEL.with(|l| {
-        *l.borrow_mut() = 0;
-    });
+  LEVEL.with(|l| {
+    *l.borrow_mut() = 0;
+  });
 }
 
 fn incr(i: &str) -> IResult<&str, ()> {
-    LEVEL.with(|l| {
-        *l.borrow_mut() += 1;
+  LEVEL.with(|l| {
+    *l.borrow_mut() += 1;
 
-        // limit the number of recursions, the fuzzer keeps running into them
-        if *l.borrow() >= 8192 {
-            return Err(nom::Err::Failure(nom::error::Error::new(i, nom::error::ErrorKind::Count)));
-        } else {
-            Ok((i, ()))
-        }
-    })
+    // limit the number of recursions, the fuzzer keeps running into them
+    if *l.borrow() >= 8192 {
+      return Err(nom::Err::Failure(nom::error::Error::new(
+        i,
+        nom::error::ErrorKind::Count,
+      )));
+    } else {
+      Ok((i, ()))
+    }
+  })
 }
 
 fn decr() {
-    LEVEL.with(|l| {
-        *l.borrow_mut() -= 1;
-    });
+  LEVEL.with(|l| {
+    *l.borrow_mut() -= 1;
+  });
 }
 
 fn parens(i: &str) -> IResult<&str, i64> {
-      delimited(space, delimited(
-              terminated(tag("("), incr),
-              expr,
-              map(tag(")"),  |_| decr())
-      ), space)(i)
+  delimited(
+    space,
+    delimited(terminated(tag("("), incr), expr, map(tag(")"), |_| decr())),
+    space,
+  ).parse(i)
 }
-
 
 fn factor(i: &str) -> IResult<&str, i64> {
   alt((
     map_res(delimited(space, digit, space), FromStr::from_str),
     parens,
-  ))(i)
+  )).parse(i)
 }
-
 
 fn term(i: &str) -> IResult<&str, i64> {
   incr(i)?;
-  let (i, init) = factor(i).map_err(|e| { decr(); e })?;
+  let (i, init) = factor(i).map_err(|e| {
+    decr();
+    e
+  })?;
 
   let res = fold_many0(
     alt((
-        pair(char('*'), factor),
-        pair(char('/'), verify(factor, |i| *i != 0)),
+      pair(char('*'), factor),
+      pair(char('/'), verify(factor, |i| *i != 0)),
     )),
     || init,
     |acc, (op, val): (char, i64)| {
@@ -79,14 +83,14 @@ fn term(i: &str) -> IResult<&str, i64> {
         acc.saturating_mul(val)
       } else {
         match acc.checked_div(val) {
-            Some(v) => v,
-            // we get a division with overflow because we can get acc = i64::MIN and val = -1
-            // the division by zero is already checked earlier by verify
-            None => i64::MAX,
+          Some(v) => v,
+          // we get a division with overflow because we can get acc = i64::MIN and val = -1
+          // the division by zero is already checked earlier by verify
+          None => i64::MAX,
         }
       }
     },
-  )(i);
+  ).parse(i);
 
   decr();
   res
@@ -94,7 +98,10 @@ fn term(i: &str) -> IResult<&str, i64> {
 
 fn expr(i: &str) -> IResult<&str, i64> {
   incr(i)?;
-  let (i, init) = term(i).map_err(|e| { decr(); e })?;
+  let (i, init) = term(i).map_err(|e| {
+    decr();
+    e
+  })?;
 
   let res = fold_many0(
     pair(alt((char('+'), char('-'))), term),
@@ -106,20 +113,20 @@ fn expr(i: &str) -> IResult<&str, i64> {
         acc.saturating_sub(val)
       }
     },
-  )(i);
+  ).parse(i);
 
   decr();
   res
 }
 
 fuzz_target!(|data: &[u8]| {
-    reset();
-    // fuzzed code goes here
-    let temp = match str::from_utf8(data) {
-        Ok(v) => {
-            //println!("v: {}", v);
-            factor(v)
-        },
-        Err(e) => factor("2"),
-    };
+  reset();
+  // fuzzed code goes here
+  let _ = match str::from_utf8(data) {
+    Ok(v) => {
+      //println!("v: {}", v);
+      factor(v)
+    }
+    Err(_) => factor("2"),
+  };
 });


### PR DESCRIPTION
Hi, This PR attempts to fix failing fuzz builds at https://oss-fuzz-build-logs.storage.googleapis.com/index.html#nom, It was showing following error in build logs
```
Step #3 - "compile-libfuzzer-address-x86_64": [0m[1m[38;5;9merror[E0618][0m[0m[1m: expected function, found `impl Parser<&str, Output = i64, Error = nom::error::Error<&str>>`[0m
```

Note: I'm confused about the cosmetic part, following format changes were applied after running `cargo +stable fmt`