### PR TITLE
Remove dependency on minimal-lexical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,9 @@ include = [
 
 [features]
 alloc = []
-std = ["alloc", "memchr/std", "minimal-lexical/std"]
+std = ["alloc", "memchr/std"]
 default = ["std"]
 docsrs = []
-
-[dependencies.minimal-lexical]
-version = "0.2.0"
-default-features = false
 
 [dependencies.memchr]
 version = "2.3"


### PR DESCRIPTION
This dependency is not actually used anywhere in the project, however it was being pulled in as a dep in the Cargo.toml. This change is simply to remove it from the Cargo.toml