### PR TITLE
Allow trailing commas in `error_node_position` and in `error_position` macros

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -610,7 +610,7 @@ impl ErrorKind {
 #[allow(unused_variables)]
 #[macro_export(local_inner_macros)]
 macro_rules! error_position(
-  ($input:expr, $code:expr) => ({
+  ($input:expr, $code:expr $(,)?) => ({
     $crate::error::make_error($input, $code)
   });
 );
@@ -621,7 +621,7 @@ macro_rules! error_position(
 #[allow(unused_variables)]
 #[macro_export(local_inner_macros)]
 macro_rules! error_node_position(
-  ($input:expr, $code:expr, $next:expr) => ({
+  ($input:expr, $code:expr, $next:expr $(,)?) => ({
     $crate::error::append_error($input, $code, $next)
   });
 );


### PR DESCRIPTION
It's quite nice when having arguments on different lines to have each line end with a comma.