### PR TITLE
Parsable trait

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1079,6 +1079,14 @@ impl<'a, R: FromStr> ParseTo<R> for &'a str {
   }
 }
 
+/// Provides a parser for a given type
+pub trait Parsable<O>: Sized {
+    /// The associated error which can be returned from parsing.
+    type Err;
+    /// Attempt to parse this type, returning an [`IResult`]
+    fn parse(s: O) -> IResult<Self, O, Self::Err>; 
+}
+
 impl<const N: usize> InputLength for [u8; N] {
   #[inline]
   fn input_len(&self) -> usize {


### PR DESCRIPTION
Adds the `Parsable` trait, a nom-ified version of std's `FromStr`