### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/benchmarks/benches/http.rs
+++ b/benchmarks/benches/http.rs
@@ -21,7 +21,7 @@ struct Header<'a> {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-#[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+#[allow(clippy::match_same_arms)]
 fn is_token(c: u8) -> bool {
   match c {
     128..=255 => false,

--- a/benchmarks/benches/http_streaming.rs
+++ b/benchmarks/benches/http_streaming.rs
@@ -21,7 +21,7 @@ struct Header<'a> {
 }
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
-#[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+#[allow(clippy::match_same_arms)]
 fn is_token(c: u8) -> bool {
   match c {
     128..=255 => false,

--- a/src/error.rs
+++ b/src/error.rs
@@ -783,7 +783,7 @@ pub fn write_color(v: &mut Vec<u8>, color: u8) {
 }
 
 #[cfg(feature = "std")]
-#[cfg_attr(feature = "cargo-clippy", allow(implicit_hasher))]
+#[allow(clippy::implicit_hasher)]
 pub fn print_codes(colors: &HashMap<u32, u8>, names: &HashMap<u32, &str>) -> String {
   let mut v = Vec::new();
   for (code, &color) in colors {


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html