### PR TITLE
fix cargo-codspeed in with workspaces in CI

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -23,12 +23,10 @@ jobs:
           bins: cargo-codspeed
 
       - name: Build the benchmark target(s)
-        working-directory: ./benchmarks
-        run: cargo codspeed build
+        run: cargo codspeed build -p benchmarks
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v2
         with:
-          working-directory: ./benchmarks
-          run: cargo codspeed run
+          run: cargo codspeed run -p benchmarks
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
This fixes the CodSpeed workflow. We released [a new version yesterday](https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/v2.5.0) and this created a regression. This will be fixed very soon, but meanwhile, these changes fix the behavior.

Sorry for the inconvenience. 

Edit: This has been fixed in [v2.5.1](https://github.com/CodSpeedHQ/codspeed-rust/releases/tag/v2.5.1) so merging this is optional and the workflow should be passing now.