### PR TITLE
Change context to pass output mode information to the child parser.

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -97,7 +97,8 @@ fn string<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
   context(
     "string",
     preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// some combinators, like `separated_list0` or `many0`, will call a parser repeatedly,
@@ -116,7 +117,8 @@ fn array<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         preceded(sp, char(']')),
       )),
     ),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn key_value<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
@@ -150,7 +152,8 @@ fn hash<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         preceded(sp, char('}')),
       )),
     ),
-  )(i)
+  )
+  .parse(i)
 }
 
 /// here, we apply the space parser before trying to parse a value

--- a/examples/json_iterator.rs
+++ b/examples/json_iterator.rs
@@ -217,7 +217,8 @@ fn string(i: &str) -> IResult<&str, &str> {
   context(
     "string",
     preceded(char('\"'), cut(terminated(parse_str, char('\"')))),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn boolean(input: &str) -> IResult<&str, bool> {
@@ -234,7 +235,8 @@ fn array(i: &str) -> IResult<&str, ()> {
         preceded(sp, char(']')),
       )),
     ),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn key_value(i: &str) -> IResult<&str, (&str, ())> {
@@ -251,7 +253,8 @@ fn hash(i: &str) -> IResult<&str, ()> {
         preceded(sp, char('}')),
       )),
     ),
-  )(i)
+  )
+  .parse(i)
 }
 
 fn value(i: &str) -> IResult<&str, ()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 //! Parsers are generic over their error type, requiring that it implements
 //! the `error::ParseError<Input>` trait.
 
-use crate::internal::Parser;
+use crate::internal::{Mode, OutputMode, PResult, Parser};
 use crate::lib::std::fmt;
 
 #[cfg(feature = "alloc")]
@@ -283,18 +283,37 @@ use crate::internal::{Err, IResult};
 /// Create a new error from an input position, a static string and an existing error.
 /// This is used mainly in the [context] combinator, to add user friendly information
 /// to errors when backtracking through a parse tree
-pub fn context<I: Clone, E: ContextError<I>, F, O>(
+pub fn context<F>(context: &'static str, parser: F) -> Context<F> {
+  Context { context, parser }
+}
+
+/// Parser implementation for [context]
+pub struct Context<F> {
   context: &'static str,
-  mut f: F,
-) -> impl FnMut(I) -> IResult<I, O, E>
+  parser: F,
+}
+
+impl<I, F> Parser<I> for Context<F>
 where
-  F: Parser<I, Output = O, Error = E>,
+  I: Clone,
+  F: Parser<I>,
+  <F as Parser<I>>::Error: ContextError<I>,
 {
-  move |i: I| match f.parse(i.clone()) {
-    Ok(o) => Ok(o),
-    Err(Err::Incomplete(i)) => Err(Err::Incomplete(i)),
-    Err(Err::Error(e)) => Err(Err::Error(E::add_context(i, context, e))),
-    Err(Err::Failure(e)) => Err(Err::Failure(E::add_context(i, context, e))),
+  type Output = <F as Parser<I>>::Output;
+  type Error = <F as Parser<I>>::Error;
+
+  fn process<OM: OutputMode>(&mut self, input: I) -> PResult<OM, I, Self::Output, Self::Error> {
+    match self.parser.process::<OM>(input.clone()) {
+      Err(Err::Error(e)) => Err(Err::Error(OM::Error::map(e, |e| {
+        <F as Parser<I>>::Error::add_context(input, self.context, e)
+      }))),
+      Err(Err::Failure(e)) => Err(Err::Failure(<F as Parser<I>>::Error::add_context(
+        input,
+        self.context,
+        e,
+      ))),
+      x => x,
+    }
   }
 }
 
@@ -667,11 +686,67 @@ where
 }
 
 #[cfg(test)]
-#[cfg(feature = "alloc")]
 mod tests {
   use super::*;
   use crate::character::complete::char;
 
+  #[test]
+  fn context_test() {
+    use crate::{character::char, combinator::cut, internal::Needed};
+
+    #[derive(Debug, PartialEq)]
+    struct Error<I> {
+      input: I,
+      ctx: Option<&'static str>,
+    }
+
+    impl<I> ParseError<I> for Error<I> {
+      fn from_error_kind(input: I, _kind: ErrorKind) -> Self {
+        Self { input, ctx: None }
+      }
+
+      fn append(input: I, _kind: ErrorKind, other: Self) -> Self {
+        Self {
+          input,
+          ctx: other.ctx,
+        }
+      }
+    }
+
+    impl<I> ContextError<I> for Error<I> {
+      fn add_context(input: I, ctx: &'static str, _other: Self) -> Self {
+        Self {
+          input,
+          ctx: Some(ctx),
+        }
+      }
+    }
+
+    assert_eq!(
+      context("ctx", char::<_, Error<_>>('a')).parse("abcd"),
+      Ok(("bcd", 'a'))
+    );
+    assert_eq!(
+      context("ctx", char::<_, Error<_>>('a')).parse(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+    assert_eq!(
+      context("ctx", char::<_, Error<_>>('a')).parse_complete(""),
+      Err(Err::Error(Error {
+        input: "",
+        ctx: Some("ctx")
+      }))
+    );
+    assert_eq!(
+      context("ctx", cut(char::<_, Error<_>>('a'))).parse("bcd"),
+      Err(Err::Failure(Error {
+        input: "bcd",
+        ctx: Some("ctx")
+      }))
+    );
+  }
+
+  #[cfg(feature = "alloc")]
   #[test]
   fn convert_error_panic() {
     let input = "";


### PR DESCRIPTION
Currently, the `nom::error::context` combinator calls `parse` on its argument, which forces it to run in streaming mode (as well as making it emit output and errors.) By directly implementing `Parser`, we can pass the `OutputMode` information down to the underlying parser.