### PR TITLE
Bump MSRV to 1.57.0 to more correctly match the codebase.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2021"
 autoexamples = false
 
 # also update in README.md (badge and "Rust version requirements" section)
-rust-version = "1.56"
+# 1.57.0 - Now using '.as_slice()'
+rust-version = "1.57.0"
 
 include = [
   "CHANGELOG.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ edition = "2021"
 autoexamples = false
 
 # also update in README.md (badge and "Rust version requirements" section)
-# 1.57.0 - Now using '.as_slice()'
-rust-version = "1.57.0"
+rust-version = "1.65.0"
 
 include = [
   "CHANGELOG.md",


### PR DESCRIPTION
As the code has been updated new features that break the currently stated MSRV have been added.

I just want  the codebase to reflect reality.

This issue can be seen by running cargo clippy 

```
warning: current MSRV (Minimum Supported Rust Version) is `1.56.0` but this item is stable since `1.57.0`
   --> src/traits.rs:649:10
    |
649 |     self.as_slice()
    |          ^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
    = note: `#[warn(clippy::incompatible_msrv)]` on by default
```
