### PR TITLE
Add support for character::*::{isize,usize} parsers

### DIFF
--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -817,7 +817,7 @@ macro_rules! ints {
     }
 }
 
-ints! { i8 i16 i32 i64 i128 }
+ints! { i8 i16 i32 i64 i128 isize }
 
 #[doc(hidden)]
 macro_rules! uints {
@@ -864,7 +864,7 @@ macro_rules! uints {
     }
 }
 
-uints! { u8 u16 u32 u64 u128 }
+uints! { u8 u16 u32 u64 u128 usize }
 
 #[cfg(test)]
 mod tests {

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -714,7 +714,7 @@ macro_rules! ints {
     }
 }
 
-ints! { i8 i16 i32 i64 i128 }
+ints! { i8 i16 i32 i64 i128 isize }
 
 #[doc(hidden)]
 macro_rules! uints {
@@ -761,7 +761,7 @@ macro_rules! uints {
     }
 }
 
-uints! { u8 u16 u32 u64 u128 }
+uints! { u8 u16 u32 u64 u128 usize }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Trivial change to add `character::{streaming,complete}::{usize,isize}` parsers. The use case is to parse item quantities which are later used in `nom::multi::count`, or to parse values which are intended to index collections without residing to needless casts.

Example use case:
```rust
use nom::character::complete::{newline, usize};
use nom::IResult;

fn parse(input: &str) -> IResult<&str, Vec<usize>> {
    let (input, count) = nom::sequence::terminated(usize, newline)(input)?;
    nom::multi::count(
        nom::sequence::terminated(usize, newline), 
        count
    )(input)
}

fn main() {
    assert_eq!(parse("3\n1\n2\n3\n"), Ok(("", vec![1, 2, 3])));
}
```

Without this change I have to complicate the code with casts:

```rust
use nom::character::complete::{newline, u32};
use nom::IResult;

fn parse(input: &str) -> IResult<&str, Vec<usize>> {
    let (input, count) = nom::sequence::terminated(u32, newline)(input)?;
    nom::multi::count(
        nom::sequence::terminated(
            nom::combinator::map(u32, |v| v as usize), 
            newline
        ),
        count as usize,
    )(input)
}

fn main() {
    assert_eq!(parse("3\n1\n2\n3\n"), Ok(("", vec![1, 2, 3])));
}
```

This change applies to both `main` and `7.x` branches, if accepted please merge to both. Test pass for both branches as well.