### PR TITLE
Implements combinator `flat_some`.

### DIFF
--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -79,6 +79,40 @@ where
   parser.map(f)
 }
 
+/// Applies a parser over the result of a parser returning an [`Option`](core::option::Option),
+/// if that result is `Some`.
+///
+/// ```rust
+/// use nom::{Err,error::ErrorKind, IResult, Parser};
+/// use nom::bytes::complete::tag;
+/// use nom::combinator::{opt, flat_some};
+/// # fn main() {
+///
+/// let mut parser = flat_some(tag("abc"), tag("def"));
+///
+/// // the parser will return Some("def") if "abc" was found first.
+/// assert_eq!(parser.parse("abcdef"), Ok(("", Some("def"))));
+///
+/// // this will return None if "abc" was not found.
+/// assert_eq!(parser.parse("xyzdef"), Ok(("xyzdef", None)));
+///
+/// // this will fail if "abc" was found but "def" was not.
+/// assert_eq!(parser.parse("abcxyz"), Err(Err::Error(("xyz", ErrorKind::Tag))));
+/// # }
+/// ```
+pub fn flat_some<I, O1, O2, E, F, G>(
+  parser: F,
+  applied_parser: G,
+) -> impl Parser<I, Output = Option<O2>, Error = E>
+where
+  E: ParseError<I>,
+  I: Clone,
+  F: Parser<I, Output = O1, Error = E>,
+  G: Parser<I, Output = O2, Error = E>,
+{
+  parser.flat_some(applied_parser)
+}
+
 /// Applies a function returning a `Result` over the result of a parser.
 ///
 /// ```rust


### PR DESCRIPTION
Hello `nom` team.

This is my very first contribution to `nom`, so I maybe did things wrong here. Also, please note that I'm quite bad at naming things, so `flat_some` might not be the most meaningful name!

I'm writing a parser using `nom` (which is a great library btw), and I came across the following pattern which I found verbose to express with `nom`, especially because I'm using it a lot:

```rust
use nom::combinator;
use nom::IResult;
use nom::bytes::complete as bytes;

fn parse_if_some<'a, 'b>(s: Option<&'a str>) -> impl Fn(&'a str) -> IResult<&'a str, Option<&'a str>> {
  move |i: &str| if s.is_some() {
      combinator::map(
          bytes::tag("next"),
          Some,
      )(i)
  } else {
    combinator::success(None)(i)
  }
}

fn parser(s: &str) -> IResult<&str, Option<&str>> {
    combinator::flat_map(
      combinator::opt(bytes::tag("first")),
      parse_if_some,
    )(s)
}

fn main() {
    assert_eq!(parser("firstnext"), Ok(("", Some("next"))));
    assert!(parser("firstinvalid").is_err());
}
```

The idea is that if a first parser succeed, then we discard its result, and apply a second one on the following input.
It is close to `sequence::preceded`, but if the first parser failed, then we return `None`, otherwise it returns either an `Error` or an `Option<O>`.

I'm using it over `combinator::opt` because I want to make sure that if I recognize a first pattern, then the following input must be correct. But if I don't recognize that first pattern, then it's fine and we can move on.

Maybe there are other "simpler" ways to do it without implementing a new combinator, and in this case I'm fine with discarding this PR. :)

<!--
Hello, and thank you for submitting a pull request to nom!

First, please note that, for family reasons, I have limited time to work on
nom, so following the advice here will make sure I will quickly understand
your work and be able to merge it early.
Second, if I don't get to work on your PR quickly, that does not mean I won't
include it later. Major version releases happen once a year, and a lot of
interesting work is merged for the occasion. So I will get back to you :)

## Prerequisites

Please provide the following information with this pull request:

- related issue number (I need some context to understand a PR with a lot of
code, except for documentation typos)
- a test case reproducing the issue. You can write it in [issues.rs](https://github.com/rust-bakery/nom/blob/main/tests/issues.rs)
- if adding a new combinator, please add code documentation and some unit tests
in the same file. Also, please update the [combinator list](https://github.com/rust-bakery/nom/blob/main/doc/choosing_a_combinator.md)

## Code style

This project follows a [code style](https://github.com/rust-bakery/nom/blob/main/rustfmt.toml)
checked by [rustfmt](https://github.com/rust-lang/rustfmt).

Please avoid cosmetic fixes unrelated to the pull request. Keeping the changes
as small as possible increase your chances of getting this merged quickly.

## Rebasing

To make sure the changes will work properly once merged into the main branch
(which might have changed while you were working on your PR), please
[rebase your PR on main](https://git-scm.com/book/en/v2/Git-Branching-Rebasing).

## Squashing the commits

If the pull request include a lot of small commits used for testing, debugging,
or correcting previous work, it might be useful to
[squash the commits](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
to make the code easier to merge.
-->
