### PR TITLE
Fix test failure in nom_recipes doc tests

### DIFF
--- a/doc/nom_recipes.md
+++ b/doc/nom_recipes.md
@@ -37,9 +37,9 @@ use nom::{
 /// trailing whitespace, returning the output of `inner`.
 pub fn ws<'a, O, E: ParseError<&'a str>, F>(
     inner: F,
-) -> impl FnMut(&'a str) -> IResult<&'a str, O, E>
+) -> impl Parser<&'a str, Output = O, Error = E>
 where
-    F: Parser<&'a str, O, E>,
+    F: Parser<&'a str, Output = O, Error = E>,
 {
     delimited(multispace0, inner, multispace0)
 }


### PR DESCRIPTION
Test failures occurred due to Parser trait changes and updates to delimited signature, with the `ws`  recipe not having been updated accordingly.