### PR TITLE
re-export nom-supreme behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,15 @@ include = [
 ]
 
 [features]
-alloc = []
+default = ["std", "supreme"]
 std = ["alloc", "memchr/std"]
-default = ["std"]
+supreme = ["std", "dep:nom-supreme"]
+
+alloc = []
 docsrs = []
+
+[dependencies]
+nom-supreme = { version = "0.8.0", optional = true }
 
 [dependencies.memchr]
 version = "2.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,9 @@ pub mod lib {
 
 pub use self::internal::*;
 pub use self::traits::*;
+#[cfg(feature = "supreme")]
+#[cfg_attr(feature = "supreme", doc(cfg(feature = "supreme")))]
+pub use nom_supreme as supreme;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
Related issue: #1785 

This PR is opinionated in the sense that the feature-gated re-export of `nom-supreme` (with the namespace `nom::supreme`) is a default feature.

I'm happy for this to be merged as-is, with a follow-up issue/PR pair for documentation (readme, book, examples, etc), or for this to be made into a draft for that followup to be rolled up into this PR.