### PR TITLE
Implement trivial Copy and ToOwned functions for Error<_>

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -802,6 +802,7 @@ mod tests {
   #[cfg(feature = "alloc")]
   #[test]
   fn clone_error() {
+    use crate::lib::std::string::String;
     let err = Error {
       code: ErrorKind::Eof,
       input: "test",

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,6 +98,48 @@ impl<I: fmt::Display> fmt::Display for Error<I> {
   }
 }
 
+#[cfg(feature = "alloc")]
+impl<I: ToOwned + ?Sized> Error<&I> {
+  /// Converts `Error<&I>` into `Error<I::Owned>` by cloning.
+  pub fn cloned(self) -> Error<I::Owned> {
+    Error {
+      input: self.input.to_owned(),
+      code: self.code,
+    }
+  }
+}
+
+#[cfg(feature = "alloc")]
+impl<I: ToOwned + ?Sized> Error<&mut I> {
+  /// Converts `Error<&mut I>` into `Error<I::Owned>` by cloning.
+  pub fn cloned(self) -> Error<I::Owned> {
+    Error {
+      input: self.input.to_owned(),
+      code: self.code,
+    }
+  }
+}
+
+impl<I: Copy> Error<&I> {
+  /// Converts `Error<&I>` into `Error<I>` by copying.
+  pub fn copied(self) -> Error<I> {
+    Error {
+      input: *self.input,
+      code: self.code,
+    }
+  }
+}
+
+impl<I: Copy> Error<&mut I> {
+  /// Converts `Error<&mut I>` into `Error<I>` by copying.
+  pub fn copied(self) -> Error<I> {
+    Error {
+      input: *self.input,
+      code: self.code,
+    }
+  }
+}
+
 #[cfg(feature = "std")]
 impl<I: fmt::Debug + fmt::Display> std::error::Error for Error<I> {}
 
@@ -755,6 +797,27 @@ mod tests {
     let input = "";
 
     let _result: IResult<_, _, VerboseError<&str>> = char('x')(input);
+  }
+
+  #[cfg(feature = "alloc")]
+  #[test]
+  fn clone_error() {
+    let err = Error {
+      code: ErrorKind::Eof,
+      input: "test",
+    };
+
+    let _err: Error<String> = err.cloned();
+  }
+
+  #[test]
+  fn copy_error() {
+    let err = Error {
+      code: ErrorKind::Eof,
+      input: &0_u8,
+    };
+
+    let _err: Error<u8> = err.copied();
   }
 }
 


### PR DESCRIPTION
I've been using nom in some of my projects. I've yet to dig into using `VerboseError` yet but I've been using the simple `Error` quite a lot for `&str` parsing. Using it inside `FromStr` has been quite ergonomic. 

However one annoyance I discovered was when returning an error from parsing a `&str`. 
Doing so returns a `Result<_, Error<&str>` which is awkward to work with since now you need to add lifetime specifiers to everything if you want to return the error as is. Assuming the trait even has the flexibility to add lifetime specifiers.

In my case I end up rebuilding the entire `Error` before returning it like so:
```rust
// result = Result<_, Error<&str>>
// fn -> Result<_, Error<String>>
return result.map_err(|Error { input, code }| Error::new(input.to_owned(), code));
```

I thought it would be trivial to add a more ergonomic method and instead of creating a feature request I thought I would just implement it myself. I ended up adding two methods to the `Error` struct:
```rust
#[cfg(feature = "alloc")]
impl<I: ToOwned + ?Sized> Error<&I> {
  /// Converts `Error<&I>` into `Error<I::Owned>` by cloning.
  pub fn cloned(self) -> Error<I::Owned> { .. }
  }
}
impl<I: Copy> Error<&I> {
  /// Converts `Error<&I>` into `Error<I>` by copying.
  pub fn copied(self) -> Error<I> { .. }
}
```
(I implemented them for `&mut` as well but omitted that above for brevity.)
This would allow my earlier conversion to be shortened to:
```rust
// result = Result<_, Error<&str>>
// fn -> Result<_, Error<String>>
return result.map_err(Error::cloned);
```

The actual implementation is exceedingly simple, I have made some tests just to ensure they have the expected behaviour but there really isn't much to test. 

I noticed the  `#[cfg(feature = "alloc")]` attribute on the import of `ToOwned` and couldn't confidently work out the reasoning behind it. Therefore I carried that attribute across to the implementations that use `ToOwned`. Feel free to remove that attribute if the restriction is unnecessary.
