### PR TITLE
Added AsByte trait (name overlaps a little with AsBytes, maybe should…

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -5,6 +5,7 @@ use core::marker::PhantomData;
 use crate::error::ParseError;
 use crate::internal::{IResult, Parser};
 use crate::traits::{Compare, FindSubstring, FindToken, ToUsize};
+use crate::AsByte;
 use crate::Complete;
 use crate::Emit;
 use crate::Input;
@@ -485,6 +486,75 @@ where
   move |i: I| parser.process::<OutputM<Emit, Emit, Complete>>(i)
 }
 
+/// Takes 1 byte and checks that it satisfies a predicate
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
+/// # use nom::bytes::complete::satisfy;
+/// fn parser(i: &[u8]) -> IResult<&[u8], u8> {
+///     satisfy(|c| c == b'a' || c == b'b')(i)
+/// }
+/// assert_eq!(parser(b"abc" as &[u8]), Ok((b"bc" as &[u8], b'a')));
+/// assert_eq!(parser(b"cd" as &[u8]), Err(Err::Error(Error::new(b"cd" as &[u8], ErrorKind::Satisfy))));
+/// assert_eq!(parser(b"" as &[u8]), Err(Err::Error(Error::new(b"" as &[u8], ErrorKind::Satisfy))));
+/// ```
+pub fn satisfy<F, I, Error: ParseError<I>>(predicate: F) -> impl FnMut(I) -> IResult<I, u8, Error>
+where
+  I: Input,
+  <I as Input>::Item: AsByte,
+  F: Fn(u8) -> bool,
+{
+  let mut parser = super::satisfy(predicate);
+  move |i: I| parser.process::<OutputM<Emit, Emit, Complete>>(i)
+}
+
+/// Matches 1 byte and checks it is equal to one of the provided bytes
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::bytes::complete::one_of;
+/// assert_eq!(one_of::<_, _, (_, ErrorKind)>(b"abc" as &[u8])(b"b" as &[u8]), Ok((b"" as &[u8], b'b')));
+/// assert_eq!(one_of::<_, _, (_, ErrorKind)>(b"a" as &[u8])(b"bc" as &[u8]), Err(Err::Error((b"bc" as &[u8], ErrorKind::OneOf))));
+/// assert_eq!(one_of::<_, _, (_, ErrorKind)>(b"a" as &[u8])(b"" as &[u8]), Err(Err::Error((b"" as &[u8], ErrorKind::OneOf))));
+/// ```
+pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, u8, Error>
+where
+  I: Input,
+  <I as Input>::Item: AsByte,
+  T: FindToken<u8>,
+{
+  let mut parser = super::one_of(list);
+  move |i: I| parser.process::<OutputM<Emit, Emit, Complete>>(i)
+}
+
+/// Recognizes a byte that is not in the provided bytes.
+///
+/// *Complete version*: Will return an error if there's not enough input data.
+/// # Example
+///
+/// ```
+/// # use nom::{Err, error::ErrorKind, Needed};
+/// # use nom::bytes::complete::none_of;
+/// assert_eq!(none_of::<_, _, (_, ErrorKind)>(b"abc" as &[u8])(b"z" as &[u8]), Ok((b"" as &[u8], b'z')));
+/// assert_eq!(none_of::<_, _, (_, ErrorKind)>(b"ab" as &[u8])(b"a" as &[u8]), Err(Err::Error((b"a" as &[u8], ErrorKind::NoneOf))));
+/// assert_eq!(none_of::<_, _, (_, ErrorKind)>(b"a" as &[u8])(b"" as &[u8]), Err(Err::Error((b"" as &[u8], ErrorKind::NoneOf))));
+/// ```
+pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, u8, Error>
+where
+  I: Input,
+  <I as Input>::Item: AsByte,
+  T: FindToken<u8>,
+{
+  let mut parser = super::none_of(list);
+  move |i: I| parser.process::<OutputM<Emit, Emit, Complete>>(i)
+}
+
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -528,7 +598,12 @@ mod tests {
 
     delimited(
       char('"'),
-      escaped(opt(none_of(r#"\""#)), '\\', one_of(r#"\"rnt"#)),
+      escaped(
+        // Specified the none_of and one_of parsers here as this PR adds none_of and one_of for the bytes::complete module
+        opt(crate::character::complete::none_of(r#"\""#)),
+        '\\',
+        crate::character::complete::one_of(r#"\"rnt"#),
+      ),
       char('"'),
     )
     .parse(input)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -855,6 +855,26 @@ impl<'a> AsChar for &'a char {
   }
 }
 
+/// Transforms common types to a single byte
+pub trait AsByte: Copy {
+  /// makes a byte from self
+  fn as_byte(self) -> u8;
+}
+
+impl AsByte for u8 {
+  #[inline]
+  fn as_byte(self) -> u8 {
+    self
+  }
+}
+
+impl<'a> AsByte for &'a u8 {
+  #[inline]
+  fn as_byte(self) -> u8 {
+    *self
+  }
+}
+
 /// Indicates whether a comparison was successful, an error, or
 /// if more data was needed
 #[derive(Debug, Eq, PartialEq)]


### PR DESCRIPTION
I just wish to preface: This is my first attempt at an open source contribution so apologies if I get things wrong, please assume ignorance or stupidity for any mistakes instead of malice.

## The problem
I was writing a parser and wanted `satisfy` for bytes, but noticed there was only a `character` version that I ultimately could've reused but it just rubbed me the wrong way doing so.

## My solution
- Adding an `AsByte` trait for `&u8` and `u8`
- Adding a near 1:1 copy of `satisfy`, `one_of` and `none_of` for `bytes::{streaming, complete}`.
- Amending the test dependent on `character::complete::{one_of, none_of}` to specify the exact function and avoid ambiguity

## Issues with my solution
- `AsByte` doesn't really do much, adding a trait with a single function and only two implementers didn't feel right but I felt parity with the `character` version was more important to meet the standards of existing code.
- The name `AsByte` overlaps a bit with `AsBytes`. To avoid changing the name of `AsBytes` to something like `AsByteSlice`, could maybe change `AsByte` to `IsByte` especially since the only two implementers are both `u8` it would be arguably more descriptive.
- Vaguely the same effect could be achieved by adding `pub use characters::_::{satisfy, one_of, none_of}` to the respective module in `bytes`, with the benefit of providing slightly less code to maintain. 
- As I wanted to copy the `character` implementation, the tests in the doc comments are a little ugly to cast the `&[u8; N]` to `&[u8]`
- I copied the `character` docs and wrote over it so I may have left some typos or uses of `char` over `u8` in there.

