### PR TITLE
[NOMERGE] Soliciting feedback on an experimental rustdoc feature

### DIFF
--- a/src/bits/complete.rs
+++ b/src/bits/complete.rs
@@ -9,26 +9,7 @@ use crate::traits::{Input, ToUsize};
 /// Generates a parser taking `count` bits
 ///
 /// # Example
-/// ```rust
-/// # use nom::bits::complete::take;
-/// # use nom::IResult;
-/// # use nom::error::{Error, ErrorKind};
-/// // Input is a tuple of (input: I, bit_offset: usize)
-/// fn parser(input: (&[u8], usize), count: usize)-> IResult<(&[u8], usize), u8> {
-///  take(count)(input)
-/// }
-///
-/// // Consumes 0 bits, returns 0
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 0), Ok((([0b00010010].as_ref(), 0), 0)));
-///
-/// // Consumes 4 bits, returns their values and increase offset to 4
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 4), Ok((([0b00010010].as_ref(), 4), 0b00000001)));
-///
-/// // Consumes 4 bits, offset is 4, returns their values and increase offset to 0 of next byte
-/// assert_eq!(parser(([0b00010010].as_ref(), 4), 4), Ok((([].as_ref(), 0), 0b00000010)));
-///
-/// // Tries to consume 12 bits but only 8 are available
-/// assert_eq!(parser(([0b00010010].as_ref(), 0), 12), Err(nom::Err::Error(Error{input: ([0b00010010].as_ref(), 0), code: ErrorKind::Eof })));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn take<I, O, C, E: ParseError<(I, usize)>>(
   count: C,
@@ -106,17 +87,7 @@ where
 /// Parses one specific bit as a bool.
 ///
 /// # Example
-/// ```rust
-/// # use nom::bits::complete::bool;
-/// # use nom::IResult;
-/// # use nom::error::{Error, ErrorKind};
-///
-/// fn parse(input: (&[u8], usize)) -> IResult<(&[u8], usize), bool> {
-///     bool(input)
-/// }
-///
-/// assert_eq!(parse(([0b10000000].as_ref(), 0)), Ok((([0b10000000].as_ref(), 1), true)));
-/// assert_eq!(parse(([0b10000000].as_ref(), 1)), Ok((([0b10000000].as_ref(), 2), false)));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn bool<I, E: ParseError<(I, usize)>>(input: (I, usize)) -> IResult<(I, usize), bool, E>
 where
@@ -190,6 +161,65 @@ mod test {
         input: (input, 8),
         code: ErrorKind::Eof
       }))
+    );
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::bits::complete::{bool, take};
+  use nom::error::{Error, ErrorKind};
+  use nom::IResult;
+
+  #[test]
+  fn example() {
+    // Input is a tuple of (input: I, bit_offset: usize)
+    fn parser(input: (&[u8], usize), count: usize) -> IResult<(&[u8], usize), u8> {
+      take(count)(input)
+    }
+
+    // Consumes 0 bits, returns 0
+    assert_eq!(
+      parser(([0b00010010].as_ref(), 0), 0),
+      Ok((([0b00010010].as_ref(), 0), 0))
+    );
+
+    // Consumes 4 bits, returns their values and increase offset to 4
+    assert_eq!(
+      parser(([0b00010010].as_ref(), 0), 4),
+      Ok((([0b00010010].as_ref(), 4), 0b00000001))
+    );
+
+    // Consumes 4 bits, offset is 4, returns their values and increase offset to 0 of next byte
+    assert_eq!(
+      parser(([0b00010010].as_ref(), 4), 4),
+      Ok((([].as_ref(), 0), 0b00000010))
+    );
+
+    // Tries to consume 12 bits but only 8 are available
+    assert_eq!(
+      parser(([0b00010010].as_ref(), 0), 12),
+      Err(nom::Err::Error(Error {
+        input: ([0b00010010].as_ref(), 0),
+        code: ErrorKind::Eof
+      }))
+    );
+  }
+
+  #[test]
+  fn example_2() {
+    fn parse(input: (&[u8], usize)) -> IResult<(&[u8], usize), bool> {
+      bool(input)
+    }
+
+    assert_eq!(
+      parse(([0b10000000].as_ref(), 0)),
+      Ok((([0b10000000].as_ref(), 1), true))
+    );
+    assert_eq!(
+      parse(([0b10000000].as_ref(), 1)),
+      Ok((([0b10000000].as_ref(), 2), false))
     );
   }
 }

--- a/src/bits/streaming.rs
+++ b/src/bits/streaming.rs
@@ -82,17 +82,7 @@ where
 /// Parses one specific bit as a bool.
 ///
 /// # Example
-/// ```rust
-/// # use nom::bits::complete::bool;
-/// # use nom::IResult;
-/// # use nom::error::{Error, ErrorKind};
-///
-/// fn parse(input: (&[u8], usize)) -> IResult<(&[u8], usize), bool> {
-///     bool(input)
-/// }
-///
-/// assert_eq!(parse(([0b10000000].as_ref(), 0)), Ok((([0b10000000].as_ref(), 1), true)));
-/// assert_eq!(parse(([0b10000000].as_ref(), 1)), Ok((([0b10000000].as_ref(), 2), false)));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn bool<I, E: ParseError<(I, usize)>>(input: (I, usize)) -> IResult<(I, usize), bool, E>
 where
@@ -166,5 +156,28 @@ mod test {
     let result: crate::IResult<(&[u8], usize), bool> = bool((input, 8));
 
     assert_eq!(result, Err(crate::Err::Incomplete(Needed::new(1))));
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::bits::complete::bool;
+  use nom::IResult;
+
+  #[test]
+  fn example_1() {
+    fn parse(input: (&[u8], usize)) -> IResult<(&[u8], usize), bool> {
+      bool(input)
+    }
+
+    assert_eq!(
+      parse(([0b10000000].as_ref(), 0)),
+      Ok((([0b10000000].as_ref(), 1), true))
+    );
+    assert_eq!(
+      parse(([0b10000000].as_ref(), 1)),
+      Ok((([0b10000000].as_ref(), 2), false))
+    );
   }
 }

--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -17,17 +17,7 @@ use crate::OutputM;
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag("Hello")(s)
-/// }
-///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn tag<T, I, Error: ParseError<I>>(tag: T) -> impl Fn(I) -> IResult<I, I, Error>
 where
@@ -51,19 +41,7 @@ where
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::Tag)))` if the input doesn't match the pattern.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::tag_no_case;
-///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag_no_case("hello")(s)
-/// }
-///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
-/// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn tag_no_case<T, I, Error: ParseError<I>>(tag: T) -> impl Fn(I) -> IResult<I, I, Error>
 where
@@ -88,18 +66,7 @@ where
 ///
 /// It will return a `Err::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::is_not;
-///
-/// fn not_space(s: &str) -> IResult<&str, &str> {
-///   is_not(" \t\r\n")(s)
-/// }
-///
-/// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
-/// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
-/// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn is_not<T, I, Error: ParseError<I>>(arr: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -118,19 +85,7 @@ where
 ///
 /// It will return a `Err(Err::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::is_a;
-///
-/// fn hex(s: &str) -> IResult<&str, &str> {
-///   is_a("1234567890ABCDEF")(s)
-/// }
-///
-/// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
-/// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
-/// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
-/// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn is_a<T, I, Error: ParseError<I>>(arr: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -147,19 +102,7 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::complete::take_while;
-/// use nom::AsChar;
-///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while(AsChar::is_alpha)(s)
-/// }
-///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
-/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn take_while<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -178,18 +121,7 @@ where
 ///
 /// It will return an `Err(Err::Error((_, ErrorKind::TakeWhile1)))` if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::take_while1;
-/// use nom::AsChar;
-///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while1(AsChar::is_alpha)(s)
-/// }
-///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn take_while1<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -209,20 +141,7 @@ where
 /// It will return an `Err::Error((_, ErrorKind::TakeWhileMN))` if the pattern wasn't met or is out
 /// of range (m <= len <= n).
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::take_while_m_n;
-/// use nom::AsChar;
-///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while_m_n(3, 6, AsChar::is_alpha)(s)
-/// }
-///
-/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn take_while_m_n<F, I, Error: ParseError<I>>(
   m: usize,
@@ -243,18 +162,7 @@ where
 /// The parser will return the longest slice till the given predicate *(a function that
 /// takes the input and returns a bool)*.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::complete::take_till;
-///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till(|c| c == ':')(s)
-/// }
-///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
-/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 #[allow(clippy::redundant_closure)]
 pub fn take_till<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
@@ -275,18 +183,7 @@ where
 /// It will return `Err(Err::Error((_, ErrorKind::TakeTill1)))` if the input is empty or the
 /// predicate matches the first input.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::take_till1;
-///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till1(|c| c == ':')(s)
-/// }
-///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
-/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Err(Err::Error(Error::new("", ErrorKind::TakeTill1))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[allow(clippy::redundant_closure)]
 pub fn take_till1<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
@@ -303,30 +200,14 @@ where
 ///
 /// It will return `Err(Err::Error((_, ErrorKind::Eof)))` if the input is shorter than the argument.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::take;
-///
-/// fn take6(s: &str) -> IResult<&str, &str> {
-///   take(6usize)(s)
-/// }
-///
-/// assert_eq!(take6("1234567"), Ok(("7", "123456")));
-/// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Error(Error::new("short", ErrorKind::Eof))));
-/// assert_eq!(take6(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 ///
 /// The units that are taken will depend on the input type. For example, for a
 /// `&str` it will take a number of `char`'s, whereas for a `&[u8]` it will
 /// take that many `u8`'s:
 ///
-/// ```rust
-/// use nom::error::Error;
-/// use nom::bytes::complete::take;
-///
-/// assert_eq!(take::<_, _, Error<_>>(1usize)("💙"), Ok(("", "💙")));
-/// assert_eq!(take::<_, _, Error<_>>(1usize)("💙".as_bytes()), Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref())));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn take<C, I, Error: ParseError<I>>(count: C) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -343,18 +224,7 @@ where
 /// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::take_until;
-///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until("eof")(s)
-/// }
-///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn take_until<T, I, Error: ParseError<I>>(tag: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -371,19 +241,7 @@ where
 /// It doesn't consume the pattern. It will return `Err(Err::Error((_, ErrorKind::TakeUntil)))`
 /// if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::take_until1;
-///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until1("eof")(s)
-/// }
-///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof(""), Err(Err::Error(Error::new("", ErrorKind::TakeUntil))));
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"), Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 pub fn take_until1<T, I, Error: ParseError<I>>(tag: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -401,18 +259,7 @@ where
 /// * The second argument is the control character (like `\` in most languages)
 /// * The third argument matches the escaped characters
 /// # Example
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use nom::character::complete::digit1;
-/// use nom::bytes::complete::escaped;
-/// use nom::character::complete::one_of;
-///
-/// fn esc(s: &str) -> IResult<&str, &str> {
-///   escaped(digit1, '\\', one_of(r#""n\"#))(s)
-/// }
-///
-/// assert_eq!(esc("123;"), Ok((";", "123")));
-/// assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 ///
 pub fn escaped<'a, I, Error, F, G>(
@@ -440,28 +287,7 @@ where
 ///
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use std::str::from_utf8;
-/// use nom::bytes::complete::{escaped_transform, tag};
-/// use nom::character::complete::alpha1;
-/// use nom::branch::alt;
-/// use nom::combinator::value;
-///
-/// fn parser(input: &str) -> IResult<&str, String> {
-///   escaped_transform(
-///     alpha1,
-///     '\\',
-///     alt((
-///       value("\\", tag("\\")),
-///       value("\"", tag("\"")),
-///       value("\n", tag("n")),
-///     ))
-///   )(input)
-/// }
-///
-/// assert_eq!(parser("ab\\\"cd"), Ok(("", String::from("ab\"cd"))));
-/// assert_eq!(parser("ab\\ncd"), Ok(("", String::from("ab\ncd"))));
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -562,5 +388,284 @@ mod tests {
       multi_byte_chars("latin", 1, 64),
       Err(Err::Error(Error::new("latin", ErrorKind::TakeWhileMN)))
     );
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::character::complete::digit1;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult,
+  };
+
+  #[test]
+  fn example_1() {
+    use nom::bytes::complete::tag;
+
+    fn parser(s: &str) -> IResult<&str, &str> {
+      tag("Hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+    assert_eq!(
+      parser("Something"),
+      Err(Err::Error(Error::new("Something", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::bytes::complete::tag_no_case;
+
+    fn parser(s: &str) -> IResult<&str, &str> {
+      tag_no_case("hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+    assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
+    assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
+    assert_eq!(
+      parser("Something"),
+      Err(Err::Error(Error::new("Something", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::bytes::complete::is_not;
+
+    fn not_space(s: &str) -> IResult<&str, &str> {
+      is_not(" \t\r\n")(s)
+    }
+
+    assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
+    assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
+    assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
+    assert_eq!(
+      not_space(""),
+      Err(Err::Error(Error::new("", ErrorKind::IsNot)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::bytes::complete::is_a;
+
+    fn hex(s: &str) -> IResult<&str, &str> {
+      is_a("1234567890ABCDEF")(s)
+    }
+
+    assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
+    assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
+    assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
+    assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
+    assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::bytes::complete::take_while;
+    use nom::AsChar;
+
+    fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while(AsChar::is_alpha)(s)
+    }
+
+    assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
+    assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+    assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::bytes::complete::take_while1;
+    use nom::AsChar;
+
+    fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while1(AsChar::is_alpha)(s)
+    }
+
+    assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+    assert_eq!(
+      alpha(b"12345"),
+      Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1)))
+    );
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::bytes::complete::take_while_m_n;
+    use nom::AsChar;
+
+    fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while_m_n(3, 6, AsChar::is_alpha)(s)
+    }
+
+    assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+    assert_eq!(short_alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+    assert_eq!(
+      short_alpha(b"ed"),
+      Err(Err::Error(Error::new(&b"ed"[..], ErrorKind::TakeWhileMN)))
+    );
+    assert_eq!(
+      short_alpha(b"12345"),
+      Err(Err::Error(Error::new(
+        &b"12345"[..],
+        ErrorKind::TakeWhileMN
+      )))
+    );
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::bytes::complete::take_till;
+
+    fn till_colon(s: &str) -> IResult<&str, &str> {
+      take_till(|c| c == ':')(s)
+    }
+
+    assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+    assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
+    assert_eq!(till_colon("12345"), Ok(("", "12345")));
+    assert_eq!(till_colon(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::bytes::complete::take_till1;
+
+    fn till_colon(s: &str) -> IResult<&str, &str> {
+      take_till1(|c| c == ':')(s)
+    }
+
+    assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+    assert_eq!(
+      till_colon(":empty matched"),
+      Err(Err::Error(Error::new(
+        ":empty matched",
+        ErrorKind::TakeTill1
+      )))
+    );
+    assert_eq!(till_colon("12345"), Ok(("", "12345")));
+    assert_eq!(
+      till_colon(""),
+      Err(Err::Error(Error::new("", ErrorKind::TakeTill1)))
+    );
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::bytes::complete::take;
+
+    fn take6(s: &str) -> IResult<&str, &str> {
+      take(6usize)(s)
+    }
+
+    assert_eq!(take6("1234567"), Ok(("7", "123456")));
+    assert_eq!(take6("things"), Ok(("", "things")));
+    assert_eq!(
+      take6("short"),
+      Err(Err::Error(Error::new("short", ErrorKind::Eof)))
+    );
+    assert_eq!(take6(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::bytes::complete::take;
+    use nom::error::Error;
+
+    assert_eq!(take::<_, _, Error<_>>(1usize)("💙"), Ok(("", "💙")));
+    assert_eq!(
+      take::<_, _, Error<_>>(1usize)("💙".as_bytes()),
+      Ok((b"\x9F\x92\x99".as_ref(), b"\xF0".as_ref()))
+    );
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::bytes::complete::take_until;
+
+    fn until_eof(s: &str) -> IResult<&str, &str> {
+      take_until("eof")(s)
+    }
+
+    assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+    assert_eq!(
+      until_eof("hello, world"),
+      Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil)))
+    );
+    assert_eq!(
+      until_eof(""),
+      Err(Err::Error(Error::new("", ErrorKind::TakeUntil)))
+    );
+    assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::bytes::complete::take_until1;
+
+    fn until_eof(s: &str) -> IResult<&str, &str> {
+      take_until1("eof")(s)
+    }
+
+    assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+    assert_eq!(
+      until_eof("hello, world"),
+      Err(Err::Error(Error::new("hello, world", ErrorKind::TakeUntil)))
+    );
+    assert_eq!(
+      until_eof(""),
+      Err(Err::Error(Error::new("", ErrorKind::TakeUntil)))
+    );
+    assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+    assert_eq!(
+      until_eof("eof"),
+      Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil)))
+    );
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::bytes::complete::escaped;
+    use nom::character::complete::one_of;
+
+    fn esc(s: &str) -> IResult<&str, &str> {
+      escaped(digit1, '\\', one_of(r#""n\"#))(s)
+    }
+
+    assert_eq!(esc("123;"), Ok((";", "123")));
+    assert_eq!(esc(r#"12\"34;"#), Ok((";", r#"12\"34"#)));
+  }
+
+  #[test]
+  fn example_15() {
+    use nom::branch::alt;
+    use nom::bytes::complete::{escaped_transform, tag};
+    use nom::character::complete::alpha1;
+    use nom::combinator::value;
+
+    fn parser(input: &str) -> IResult<&str, String> {
+      escaped_transform(
+        alpha1,
+        '\\',
+        alt((
+          value("\\", tag("\\")),
+          value("\"", tag("\"")),
+          value("\n", tag("n")),
+        )),
+      )(input)
+    }
+
+    assert_eq!(parser("ab\\\"cd"), Ok(("", String::from("ab\"cd"))));
+    assert_eq!(parser("ab\\ncd"), Ok(("", String::from("ab\ncd"))));
   }
 }

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -29,18 +29,7 @@ use crate::ToUsize;
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag("Hello")(s)
-/// }
-///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser("S"), Err(Err::Error(Error::new("S", ErrorKind::Tag))));
-/// assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn tag<T, I, Error: ParseError<I>>(tag: T) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -97,19 +86,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::tag_no_case;
-///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag_no_case("hello")(s)
-/// }
-///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
-/// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn tag_no_case<T, I, Error: ParseError<I>>(tag: T) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -212,18 +189,7 @@ where
 ///
 /// It will return a `Err::Error(("", ErrorKind::IsNot))` if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::is_not;
-///
-/// fn not_space(s: &str) -> IResult<&str, &str> {
-///   is_not(" \t\r\n")(s)
-/// }
-///
-/// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
-/// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
-/// assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
-/// assert_eq!(not_space(""), Err(Err::Error(Error::new("", ErrorKind::IsNot))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn is_not<T, I, Error: ParseError<I>>(arr: T) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -244,19 +210,7 @@ where
 ///
 /// It will return a `Err(Err::Error((_, ErrorKind::IsA)))` if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::complete::is_a;
-///
-/// fn hex(s: &str) -> IResult<&str, &str> {
-///   is_a("1234567890ABCDEF")(s)
-/// }
-///
-/// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
-/// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
-/// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
-/// assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
-/// assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn is_a<T, I, Error: ParseError<I>>(arr: T) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -275,19 +229,7 @@ where
 /// The parser will return the longest slice that matches the given predicate *(a function that
 /// takes the input and returns a bool)*.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::complete::take_while;
-/// use nom::character::is_alphabetic;
-///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while(is_alphabetic)(s)
-/// }
-///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
-/// assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
-/// assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn take_while<F, I, Error: ParseError<I>>(cond: F) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -311,18 +253,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_while1;
-/// use nom::character::is_alphabetic;
-///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while1(is_alphabetic)(s)
-/// }
-///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn take_while1<F, I, Error: ParseError<I>>(cond: F) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -346,20 +277,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_while_m_n;
-/// use nom::character::is_alphabetic;
-///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while_m_n(3, 6, is_alphabetic)(s)
-/// }
-///
-/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn take_while_m_n<F, I, Error: ParseError<I>>(
   m: usize,
@@ -448,18 +366,7 @@ where
 /// The parser will return the longest slice till the given predicate *(a function that
 /// takes the input and returns a bool)*.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::complete::take_till;
-///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till(|c| c == ':')(s)
-/// }
-///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
-/// assert_eq!(till_colon("12345"), Ok(("", "12345")));
-/// assert_eq!(till_colon(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 #[allow(clippy::redundant_closure)]
 pub fn take_till<F, I, Error: ParseError<I>>(cond: F) -> impl Parser<I, Output = I, Error = Error>
@@ -482,18 +389,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_till1;
-///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till1(|c| c == ':')(s)
-/// }
-///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
-/// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[allow(clippy::redundant_closure)]
 pub fn take_till1<F, I, Error: ParseError<I>>(cond: F) -> impl Parser<I, Output = I, Error = Error>
@@ -519,17 +415,7 @@ where
 /// the next few chars, so the result will be `Err::Incomplete(Needed::Unknown)`
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::take;
-///
-/// fn take6(s: &str) -> IResult<&str, &str> {
-///   take(6usize)(s)
-/// }
-///
-/// assert_eq!(take6("1234567"), Ok(("7", "123456")));
-/// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Unknown)));
+/// ```rust,{source="doctests:example_10"},ignore
 /// ```
 pub fn take<C, I, Error: ParseError<I>>(count: C) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -580,18 +466,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::take_until;
-///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until("eof")(s)
-/// }
-///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn take_until<T, I, Error: ParseError<I>>(tag: T) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -643,19 +518,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_until1;
-///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until1("eof")(s)
-/// }
-///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"),  Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn take_until1<T, I, Error: ParseError<I>>(tag: T) -> impl Parser<I, Output = I, Error = Error>
 where
@@ -709,18 +572,7 @@ where
 /// * The second argument is the control character (like `\` in most languages)
 /// * The third argument matches the escaped characters
 /// # Example
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use nom::character::complete::digit1;
-/// use nom::bytes::streaming::escaped;
-/// use nom::character::streaming::one_of;
-///
-/// fn esc(s: &str) -> IResult<&str, &str> {
-///   escaped(digit1, '\\', one_of("\"n\\"))(s)
-/// }
-///
-/// assert_eq!(esc("123;"), Ok((";", "123")));
-/// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 ///
 pub fn escaped<I, Error, F, G>(
@@ -874,27 +726,7 @@ where
 ///
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use std::str::from_utf8;
-/// use nom::bytes::streaming::{escaped_transform, tag};
-/// use nom::character::streaming::alpha1;
-/// use nom::branch::alt;
-/// use nom::combinator::value;
-///
-/// fn parser(input: &str) -> IResult<&str, String> {
-///   escaped_transform(
-///     alpha1,
-///     '\\',
-///     alt((
-///       value("\\", tag("\\")),
-///       value("\"", tag("\"")),
-///       value("\n", tag("n")),
-///     ))
-///   )(input)
-/// }
-///
-/// assert_eq!(parser("ab\\\"cd\""), Ok(("\"", String::from("ab\"cd"))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -1040,5 +872,265 @@ where
     } else {
       Ok((input.take_from(index), res))
     }
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::character::complete::digit1;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult, Needed,
+  };
+
+  #[test]
+  fn example_1() {
+    use nom::bytes::streaming::tag;
+
+    fn parser(s: &str) -> IResult<&str, &str> {
+      tag("Hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+    assert_eq!(
+      parser("Something"),
+      Err(Err::Error(Error::new("Something", ErrorKind::Tag)))
+    );
+    assert_eq!(
+      parser("S"),
+      Err(Err::Error(Error::new("S", ErrorKind::Tag)))
+    );
+    assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::bytes::streaming::tag_no_case;
+
+    fn parser(s: &str) -> IResult<&str, &str> {
+      tag_no_case("hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+    assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
+    assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
+    assert_eq!(
+      parser("Something"),
+      Err(Err::Error(Error::new("Something", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::bytes::complete::is_not;
+
+    fn not_space(s: &str) -> IResult<&str, &str> {
+      is_not(" \t\r\n")(s)
+    }
+
+    assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
+    assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
+    assert_eq!(not_space("Nospace"), Ok(("", "Nospace")));
+    assert_eq!(
+      not_space(""),
+      Err(Err::Error(Error::new("", ErrorKind::IsNot)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::bytes::complete::is_a;
+
+    fn hex(s: &str) -> IResult<&str, &str> {
+      is_a("1234567890ABCDEF")(s)
+    }
+
+    assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
+    assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
+    assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
+    assert_eq!(hex("D15EA5E"), Ok(("", "D15EA5E")));
+    assert_eq!(hex(""), Err(Err::Error(Error::new("", ErrorKind::IsA))));
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::bytes::complete::take_while;
+    use nom::character::is_alphabetic;
+
+    fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while(is_alphabetic)(s)
+    }
+
+    assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
+    assert_eq!(alpha(b"latin"), Ok((&b""[..], &b"latin"[..])));
+    assert_eq!(alpha(b""), Ok((&b""[..], &b""[..])));
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::bytes::streaming::take_while1;
+    use nom::character::is_alphabetic;
+
+    fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while1(is_alphabetic)(s)
+    }
+
+    assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(
+      alpha(b"12345"),
+      Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1)))
+    );
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::bytes::streaming::take_while_m_n;
+    use nom::character::is_alphabetic;
+
+    fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while_m_n(3, 6, is_alphabetic)(s)
+    }
+
+    assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+    assert_eq!(short_alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(
+      short_alpha(b"12345"),
+      Err(Err::Error(Error::new(
+        &b"12345"[..],
+        ErrorKind::TakeWhileMN
+      )))
+    );
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::bytes::complete::take_till;
+
+    fn till_colon(s: &str) -> IResult<&str, &str> {
+      take_till(|c| c == ':')(s)
+    }
+
+    assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+    assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
+    assert_eq!(till_colon("12345"), Ok(("", "12345")));
+    assert_eq!(till_colon(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::bytes::streaming::take_till1;
+
+    fn till_colon(s: &str) -> IResult<&str, &str> {
+      take_till1(|c| c == ':')(s)
+    }
+
+    assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+    assert_eq!(
+      till_colon(":empty matched"),
+      Err(Err::Error(Error::new(
+        ":empty matched",
+        ErrorKind::TakeTill1
+      )))
+    );
+    assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::bytes::streaming::take;
+
+    fn take6(s: &str) -> IResult<&str, &str> {
+      take(6usize)(s)
+    }
+
+    assert_eq!(take6("1234567"), Ok(("7", "123456")));
+    assert_eq!(take6("things"), Ok(("", "things")));
+    assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Unknown)));
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::bytes::streaming::take_until;
+
+    fn until_eof(s: &str) -> IResult<&str, &str> {
+      take_until("eof")(s)
+    }
+
+    assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+    assert_eq!(
+      until_eof("hello, world"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+      until_eof("hello, worldeo"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::bytes::streaming::take_until1;
+
+    fn until_eof(s: &str) -> IResult<&str, &str> {
+      take_until1("eof")(s)
+    }
+
+    assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+    assert_eq!(
+      until_eof("hello, world"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+      until_eof("hello, worldeo"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+    assert_eq!(
+      until_eof("eof"),
+      Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::bytes::streaming::escaped;
+    use nom::character::streaming::one_of;
+
+    fn esc(s: &str) -> IResult<&str, &str> {
+      escaped(digit1, '\\', one_of("\"n\\"))(s)
+    }
+
+    assert_eq!(esc("123;"), Ok((";", "123")));
+    assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::branch::alt;
+    use nom::bytes::streaming::{escaped_transform, tag};
+    use nom::character::streaming::alpha1;
+    use nom::combinator::value;
+
+    fn parser(input: &str) -> IResult<&str, String> {
+      escaped_transform(
+        alpha1,
+        '\\',
+        alt((
+          value("\\", tag("\\")),
+          value("\"", tag("\"")),
+          value("\n", tag("n")),
+        )),
+      )(input)
+    }
+
+    assert_eq!(parser("ab\\\"cd\""), Ok(("\"", String::from("ab\"cd"))));
   }
 }

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -15,18 +15,7 @@ use crate::Streaming;
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag("Hello")(s)
-/// }
-///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser("S"), Err(Err::Error(Error::new("S", ErrorKind::Tag))));
-/// assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn tag<T, I, Error: ParseError<I>>(tag: T) -> impl Fn(I) -> IResult<I, I, Error>
 where
@@ -48,19 +37,7 @@ where
 /// The input data will be compared to the tag combinator's argument and will return the part of
 /// the input that matches the argument with no regard to case.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::tag_no_case;
-///
-/// fn parser(s: &str) -> IResult<&str, &str> {
-///   tag_no_case("hello")(s)
-/// }
-///
-/// assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
-/// assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
-/// assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
-/// assert_eq!(parser("Something"), Err(Err::Error(Error::new("Something", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn tag_no_case<T, I, Error: ParseError<I>>(tag: T) -> impl Fn(I) -> IResult<I, I, Error>
 where
@@ -85,18 +62,7 @@ where
 ///
 /// It will return a `Err::Incomplete(Needed::new(1))` if the pattern wasn't met.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::is_not;
-///
-/// fn not_space(s: &str) -> IResult<&str, &str> {
-///   is_not(" \t\r\n")(s)
-/// }
-///
-/// assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
-/// assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
-/// assert_eq!(not_space("Nospace"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(not_space(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn is_not<T, I, Error: ParseError<I>>(arr: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -117,19 +83,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the pattern wasn't met
 /// or if the pattern reaches the end of the input.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::is_a;
-///
-/// fn hex(s: &str) -> IResult<&str, &str> {
-///   is_a("1234567890ABCDEF")(s)
-/// }
-///
-/// assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
-/// assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
-/// assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
-/// assert_eq!(hex("D15EA5E"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(hex(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn is_a<T, I, Error: ParseError<I>>(arr: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -149,19 +103,7 @@ where
 /// # Streaming Specific
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the pattern reaches the end of the input.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::take_while;
-/// use nom::AsChar;
-///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while(AsChar::is_alpha)(s)
-/// }
-///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
-/// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(b""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctest::example_5"},ignore
 /// ```
 pub fn take_while<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -184,18 +126,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` or if the pattern reaches the end of the input.
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_while1;
-/// use nom::AsChar;
-///
-/// fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while1(AsChar::is_alpha)(s)
-/// }
-///
-/// assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn take_while1<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -217,20 +148,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))`  if the pattern reaches the end of the input or is too short.
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_while_m_n;
-/// use nom::AsChar;
-///
-/// fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   take_while_m_n(3, 6, AsChar::is_alpha)(s)
-/// }
-///
-/// assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
-/// assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
-/// assert_eq!(short_alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(short_alpha(b"12345"), Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhileMN))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn take_while_m_n<F, I, Error: ParseError<I>>(
   m: usize,
@@ -256,18 +174,7 @@ where
 /// end of input or if there was not match.
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::take_till;
-///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till(|c| c == ':')(s)
-/// }
-///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
-/// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 #[allow(clippy::redundant_closure)]
 pub fn take_till<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
@@ -289,18 +196,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(1))` if the match reaches the
 /// end of input or if there was not match.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_till1;
-///
-/// fn till_colon(s: &str) -> IResult<&str, &str> {
-///   take_till1(|c| c == ':')(s)
-/// }
-///
-/// assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
-/// assert_eq!(till_colon(":empty matched"), Err(Err::Error(Error::new(":empty matched", ErrorKind::TakeTill1))));
-/// assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[allow(clippy::redundant_closure)]
 pub fn take_till1<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, I, Error>
@@ -324,17 +220,7 @@ where
 /// the next few chars, so the result will be `Err::Incomplete(Needed::Unknown)`
 ///
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::take;
-///
-/// fn take6(s: &str) -> IResult<&str, &str> {
-///   take(6usize)(s)
-/// }
-///
-/// assert_eq!(take6("1234567"), Ok(("7", "123456")));
-/// assert_eq!(take6("things"), Ok(("", "things")));
-/// assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Unknown)));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 pub fn take<C, I, Error: ParseError<I>>(count: C) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -354,18 +240,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// use nom::bytes::streaming::take_until;
-///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until("eof")(s)
-/// }
-///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn take_until<T, I, Error: ParseError<I>>(tag: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -385,19 +260,7 @@ where
 /// *Streaming version* will return a `Err::Incomplete(Needed::new(N))` if the input doesn't
 /// contain the pattern or if the input is smaller than the pattern.
 /// # Example
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult};
-/// use nom::bytes::streaming::take_until1;
-///
-/// fn until_eof(s: &str) -> IResult<&str, &str> {
-///   take_until1("eof")(s)
-/// }
-///
-/// assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
-/// assert_eq!(until_eof("hello, world"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("hello, worldeo"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
-/// assert_eq!(until_eof("eof"),  Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn take_until1<T, I, Error: ParseError<I>>(tag: T) -> impl FnMut(I) -> IResult<I, I, Error>
 where
@@ -415,18 +278,7 @@ where
 /// * The second argument is the control character (like `\` in most languages)
 /// * The third argument matches the escaped characters
 /// # Example
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use nom::character::complete::digit1;
-/// use nom::bytes::streaming::escaped;
-/// use nom::character::streaming::one_of;
-///
-/// fn esc(s: &str) -> IResult<&str, &str> {
-///   escaped(digit1, '\\', one_of("\"n\\"))(s)
-/// }
-///
-/// assert_eq!(esc("123;"), Ok((";", "123")));
-/// assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 ///
 pub fn escaped<I, Error, F, G>(
@@ -454,27 +306,7 @@ where
 ///
 /// As an example, the chain `abc\tdef` could be `abc    def` (it also consumes the control character)
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed, IResult};
-/// # use std::str::from_utf8;
-/// use nom::bytes::streaming::{escaped_transform, tag};
-/// use nom::character::streaming::alpha1;
-/// use nom::branch::alt;
-/// use nom::combinator::value;
-///
-/// fn parser(input: &str) -> IResult<&str, String> {
-///   escaped_transform(
-///     alpha1,
-///     '\\',
-///     alt((
-///       value("\\", tag("\\")),
-///       value("\"", tag("\"")),
-///       value("\n", tag("n")),
-///     ))
-///   )(input)
-/// }
-///
-/// assert_eq!(parser("ab\\\"cd\""), Ok(("\"", String::from("ab\"cd"))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -496,4 +328,261 @@ where
   let mut parser = super::escaped_transform(normal, control_char, transform);
 
   move |i: I| parser.process::<OutputM<Emit, Emit, Streaming>>(i)
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::character::complete::digit1;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult, Needed,
+  };
+
+  #[test]
+  fn example_1() {
+    use nom::bytes::streaming::tag;
+
+    fn parser(s: &str) -> IResult<&str, &str> {
+      tag("Hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+    assert_eq!(
+      parser("Something"),
+      Err(Err::Error(Error::new("Something", ErrorKind::Tag)))
+    );
+    assert_eq!(
+      parser("S"),
+      Err(Err::Error(Error::new("S", ErrorKind::Tag)))
+    );
+    assert_eq!(parser("H"), Err(Err::Incomplete(Needed::new(4))));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::bytes::streaming::tag_no_case;
+
+    fn parser(s: &str) -> IResult<&str, &str> {
+      tag_no_case("hello")(s)
+    }
+
+    assert_eq!(parser("Hello, World!"), Ok((", World!", "Hello")));
+    assert_eq!(parser("hello, World!"), Ok((", World!", "hello")));
+    assert_eq!(parser("HeLlO, World!"), Ok((", World!", "HeLlO")));
+    assert_eq!(
+      parser("Something"),
+      Err(Err::Error(Error::new("Something", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(5))));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::bytes::streaming::is_not;
+
+    fn not_space(s: &str) -> IResult<&str, &str> {
+      is_not(" \t\r\n")(s)
+    }
+
+    assert_eq!(not_space("Hello, World!"), Ok((" World!", "Hello,")));
+    assert_eq!(not_space("Sometimes\t"), Ok(("\t", "Sometimes")));
+    assert_eq!(not_space("Nospace"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(not_space(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::bytes::streaming::is_a;
+
+    fn hex(s: &str) -> IResult<&str, &str> {
+      is_a("1234567890ABCDEF")(s)
+    }
+
+    assert_eq!(hex("123 and voila"), Ok((" and voila", "123")));
+    assert_eq!(hex("DEADBEEF and others"), Ok((" and others", "DEADBEEF")));
+    assert_eq!(hex("BADBABEsomething"), Ok(("something", "BADBABE")));
+    assert_eq!(hex("D15EA5E"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(hex(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::bytes::streaming::take_while;
+    use nom::AsChar;
+
+    fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while(AsChar::is_alpha)(s)
+    }
+
+    assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(alpha(b"12345"), Ok((&b"12345"[..], &b""[..])));
+    assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(alpha(b""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::bytes::streaming::take_while1;
+    use nom::AsChar;
+
+    fn alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while1(AsChar::is_alpha)(s)
+    }
+
+    assert_eq!(alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(
+      alpha(b"12345"),
+      Err(Err::Error(Error::new(&b"12345"[..], ErrorKind::TakeWhile1)))
+    );
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::bytes::streaming::take_while_m_n;
+    use nom::AsChar;
+
+    fn short_alpha(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      take_while_m_n(3, 6, AsChar::is_alpha)(s)
+    }
+
+    assert_eq!(short_alpha(b"latin123"), Ok((&b"123"[..], &b"latin"[..])));
+    assert_eq!(short_alpha(b"lengthy"), Ok((&b"y"[..], &b"length"[..])));
+    assert_eq!(short_alpha(b"latin"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(short_alpha(b"ed"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(
+      short_alpha(b"12345"),
+      Err(Err::Error(Error::new(
+        &b"12345"[..],
+        ErrorKind::TakeWhileMN
+      )))
+    );
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::bytes::streaming::take_till;
+
+    fn till_colon(s: &str) -> IResult<&str, &str> {
+      take_till(|c| c == ':')(s)
+    }
+
+    assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+    assert_eq!(till_colon(":empty matched"), Ok((":empty matched", ""))); //allowed
+    assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::bytes::streaming::take_till1;
+
+    fn till_colon(s: &str) -> IResult<&str, &str> {
+      take_till1(|c| c == ':')(s)
+    }
+
+    assert_eq!(till_colon("latin:123"), Ok((":123", "latin")));
+    assert_eq!(
+      till_colon(":empty matched"),
+      Err(Err::Error(Error::new(
+        ":empty matched",
+        ErrorKind::TakeTill1
+      )))
+    );
+    assert_eq!(till_colon("12345"), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(till_colon(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::bytes::streaming::take;
+
+    fn take6(s: &str) -> IResult<&str, &str> {
+      take(6usize)(s)
+    }
+
+    assert_eq!(take6("1234567"), Ok(("7", "123456")));
+    assert_eq!(take6("things"), Ok(("", "things")));
+    assert_eq!(take6("short"), Err(Err::Incomplete(Needed::Unknown)));
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::bytes::streaming::take_until;
+
+    fn until_eof(s: &str) -> IResult<&str, &str> {
+      take_until("eof")(s)
+    }
+
+    assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+    assert_eq!(
+      until_eof("hello, world"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+      until_eof("hello, worldeo"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::bytes::streaming::take_until1;
+
+    fn until_eof(s: &str) -> IResult<&str, &str> {
+      take_until1("eof")(s)
+    }
+
+    assert_eq!(until_eof("hello, worldeof"), Ok(("eof", "hello, world")));
+    assert_eq!(
+      until_eof("hello, world"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+      until_eof("hello, worldeo"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(until_eof("1eof2eof"), Ok(("eof2eof", "1")));
+    assert_eq!(
+      until_eof("eof"),
+      Err(Err::Error(Error::new("eof", ErrorKind::TakeUntil)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::bytes::streaming::escaped;
+    use nom::character::streaming::one_of;
+
+    fn esc(s: &str) -> IResult<&str, &str> {
+      escaped(digit1, '\\', one_of("\"n\\"))(s)
+    }
+
+    assert_eq!(esc("123;"), Ok((";", "123")));
+    assert_eq!(esc("12\\\"34;"), Ok((";", "12\\\"34")));
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::branch::alt;
+    use nom::bytes::streaming::{escaped_transform, tag};
+    use nom::character::streaming::alpha1;
+    use nom::combinator::value;
+
+    fn parser(input: &str) -> IResult<&str, String> {
+      escaped_transform(
+        alpha1,
+        '\\',
+        alt((
+          value("\\", tag("\\")),
+          value("\"", tag("\"")),
+          value("\n", tag("n")),
+        )),
+      )(input)
+    }
+
+    assert_eq!(parser("ab\\\"cd\""), Ok(("\"", String::from("ab\"cd"))));
+  }
 }

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -872,7 +872,7 @@ mod tests {
   use crate::internal::Err;
   use crate::traits::ParseTo;
   use crate::Parser;
-  use proptest::prelude::*;
+  //use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -1285,19 +1285,19 @@ mod tests {
     }
   }
 
-  proptest! {
-    #[test]
-    fn ints(s in "\\PC*") {
-        let res1 = digit_to_i16(&s);
-        let res2 = i16(s.as_str());
-        assert_eq!(res1, res2);
-    }
+  // proptest! {
+  //   #[test]
+  //   fn ints(s in "\\PC*") {
+  //       let res1 = digit_to_i16(&s);
+  //       let res2 = i16(s.as_str());
+  //       assert_eq!(res1, res2);
+  //   }
 
-    #[test]
-    fn uints(s in "\\PC*") {
-        let res1 = digit_to_u32(&s);
-        let res2 = u32(s.as_str());
-        assert_eq!(res1, res2);
-    }
-  }
+  //   #[test]
+  //   fn uints(s in "\\PC*") {
+  //       let res1 = digit_to_u32(&s);
+  //       let res2 = u32(s.as_str());
+  //       assert_eq!(res1, res2);
+  //   }
+  // }
 }

--- a/src/character/complete.rs
+++ b/src/character/complete.rs
@@ -19,16 +19,7 @@ use crate::Parser;
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, IResult};
-/// # use nom::character::complete::char;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     char('a')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser(" abc"), Err(Err::Error(Error::new(" abc", ErrorKind::Char))));
-/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```rust,{source=doctests::example_1},ignore
 /// ```
 pub fn char<I, Error: ParseError<I>>(c: char) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -44,15 +35,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::character::complete::satisfy;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     satisfy(|c| c == 'a' || c == 'b')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn satisfy<F, I, Error: ParseError<I>>(predicate: F) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -69,12 +52,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind};
-/// # use nom::character::complete::one_of;
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -91,12 +69,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind};
-/// # use nom::character::complete::none_of;
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::NoneOf))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -113,16 +86,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult};
-/// # use nom::character::complete::crlf;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     crlf(input)
-/// }
-///
-/// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn crlf<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -144,19 +108,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::not_line_ending;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     not_line_ending(input)
-/// }
-///
-/// assert_eq!(parser("ab\r\nc"), Ok(("\r\nc", "ab")));
-/// assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
-/// assert_eq!(parser("abc"), Ok(("", "abc")));
-/// assert_eq!(parser(""), Ok(("", "")));
-/// assert_eq!(parser("a\rb\nc"), Err(Err::Error(Error { input: "a\rb\nc", code: ErrorKind::Tag })));
-/// assert_eq!(parser("a\rbc"), Err(Err::Error(Error { input: "a\rbc", code: ErrorKind::Tag })));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -195,16 +147,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::line_ending;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     line_ending(input)
-/// }
-///
-/// assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(parser("ab\r\nc"), Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -226,16 +169,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::newline;
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     newline(input)
-/// }
-///
-/// assert_eq!(parser("\nc"), Ok(("c", '\n')));
-/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
@@ -250,16 +184,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::tab;
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     tab(input)
-/// }
-///
-/// assert_eq!(parser("\tc"), Ok(("c", '\t')));
-/// assert_eq!(parser("\r\nc"), Err(Err::Error(Error::new("\r\nc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
@@ -275,14 +200,7 @@ where
 /// *Complete version*: Will return an error if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{character::complete::anychar, Err, error::{Error, ErrorKind}, IResult};
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     anychar(input)
-/// }
-///
-/// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
@@ -302,16 +220,7 @@ where
 /// alphabetic character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::alpha0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alpha0(input)
-/// }
-///
-/// assert_eq!(parser("ab1c"), Ok(("1c", "ab")));
-/// assert_eq!(parser("1c"), Ok(("1c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -327,16 +236,7 @@ where
 /// or the whole input if no terminating token is found  (a non alphabetic character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::alpha1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alpha1(input)
-/// }
-///
-/// assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(parser("1c"), Err(Err::Error(Error::new("1c", ErrorKind::Alpha))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Alpha))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -352,17 +252,7 @@ where
 /// or the whole input if no terminating token is found (a non digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     digit0(input)
-/// }
-///
-/// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("21"), Ok(("", "21")));
-/// assert_eq!(parser("a21c"), Ok(("a21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -378,32 +268,13 @@ where
 /// or the whole input if no terminating token is found (a non digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     digit1(input)
-/// }
-///
-/// assert_eq!(parser("21c"), Ok(("c", "21")));
-/// assert_eq!(parser("c1"), Err(Err::Error(Error::new("c1", ErrorKind::Digit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Digit))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 ///
 /// ## Parsing an integer
 /// You can use `digit1` in combination with [`map_res`] to parse an integer:
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed, Parser};
-/// # use nom::combinator::map_res;
-/// # use nom::character::complete::digit1;
-/// fn parser(input: &str) -> IResult<&str, u32> {
-///   map_res(digit1, str::parse).parse(input)
-/// }
-///
-/// assert_eq!(parser("416"), Ok(("", 416)));
-/// assert_eq!(parser("12b"), Ok(("b", 12)));
-/// assert!(parser("b").is_err());
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 ///
 /// [`map_res`]: crate::combinator::map_res
@@ -420,16 +291,7 @@ where
 /// *Complete version*: Will return the whole input if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::hex_digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     hex_digit0(input)
-/// }
-///
-/// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_16"},ignore
 /// ```
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -444,16 +306,7 @@ where
 /// or the whole input if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::hex_digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     hex_digit1(input)
-/// }
-///
-/// assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::HexDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::HexDigit))));
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -469,16 +322,7 @@ where
 /// digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::oct_digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     oct_digit0(input)
-/// }
-///
-/// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -494,16 +338,7 @@ where
 /// or the whole input if no terminating token is found (a non octal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::oct_digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     oct_digit1(input)
-/// }
-///
-/// assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::OctDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::OctDigit))));
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -519,16 +354,7 @@ where
 /// digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::bin_digit0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     bin_digit0(input)
-/// }
-///
-/// assert_eq!(parser("013a"), Ok(("3a", "01")));
-/// assert_eq!(parser("a013"), Ok(("a013", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 pub fn bin_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -544,16 +370,7 @@ where
 /// or the whole input if no terminating token is found (a non binary digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::bin_digit1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     bin_digit1(input)
-/// }
-///
-/// assert_eq!(parser("013a"), Ok(("3a", "01")));
-/// assert_eq!(parser("a013"), Err(Err::Error(Error::new("a013", ErrorKind::BinDigit))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::BinDigit))));
+/// ```rust,{source="doctests::example_21"},ignore
 /// ```
 pub fn bin_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -569,16 +386,7 @@ where
 /// alphanumerical character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::alphanumeric0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alphanumeric0(input)
-/// }
-///
-/// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&Z21c"), Ok(("&Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_22"},ignore
 /// ```
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -594,16 +402,7 @@ where
 /// or the whole input if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::alphanumeric1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     alphanumeric1(input)
-/// }
-///
-/// assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(parser("&H2"), Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::AlphaNumeric))));
+/// ```rust,{source="doctests::example_23"},ignore
 /// ```
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -619,16 +418,7 @@ where
 /// character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::space0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     space0(input)
-/// }
-///
-/// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_24"},ignore
 /// ```
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -647,16 +437,7 @@ where
 /// or the whole input if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::space1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     space1(input)
-/// }
-///
-/// assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::Space))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Space))));
+/// ```rust,{source="doctests::example_25"},ignore
 /// ```
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -678,16 +459,7 @@ where
 /// character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::complete::multispace0;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     multispace0(input)
-/// }
-///
-/// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(parser(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_26"},ignore
 /// ```
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -706,16 +478,7 @@ where
 /// or the whole input if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::complete::multispace1;
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///     multispace1(input)
-/// }
-///
-/// assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(parser("H2"), Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::MultiSpace))));
+/// ```rust,{source="doctests::example_27"},ignore
 /// ```
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -1300,4 +1063,406 @@ mod tests {
   //       assert_eq!(res1, res2);
   //   }
   // }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use super::*;
+
+  use crate as nom;
+  use nom::combinator::map_res;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult,
+  };
+
+  #[test]
+  fn example_1() {
+    fn parser(i: &str) -> IResult<&str, char> {
+      char('a')(i)
+    }
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      parser(" abc"),
+      Err(Err::Error(Error::new(" abc", ErrorKind::Char)))
+    );
+    assert_eq!(
+      parser("bc"),
+      Err(Err::Error(Error::new("bc", ErrorKind::Char)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+  }
+
+  #[test]
+  fn example_2() {
+    fn parser(i: &str) -> IResult<&str, char> {
+      satisfy(|c| c == 'a' || c == 'b')(i)
+    }
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      parser("cd"),
+      Err(Err::Error(Error::new("cd", ErrorKind::Satisfy)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Satisfy)))
+    );
+  }
+
+  #[test]
+  fn example_3() {
+    assert_eq!(one_of::<_, _, (&str, ErrorKind)>("abc")("b"), Ok(("", 'b')));
+    assert_eq!(
+      one_of::<_, _, (&str, ErrorKind)>("a")("bc"),
+      Err(Err::Error(("bc", ErrorKind::OneOf)))
+    );
+    assert_eq!(
+      one_of::<_, _, (&str, ErrorKind)>("a")(""),
+      Err(Err::Error(("", ErrorKind::OneOf)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    assert_eq!(
+      none_of::<_, _, (&str, ErrorKind)>("abc")("z"),
+      Ok(("", 'z'))
+    );
+    assert_eq!(
+      none_of::<_, _, (&str, ErrorKind)>("ab")("a"),
+      Err(Err::Error(("a", ErrorKind::NoneOf)))
+    );
+    assert_eq!(
+      none_of::<_, _, (&str, ErrorKind)>("a")(""),
+      Err(Err::Error(("", ErrorKind::NoneOf)))
+    );
+  }
+
+  #[test]
+  fn example_5() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      crlf(input)
+    }
+
+    assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
+    assert_eq!(
+      parser("ab\r\nc"),
+      Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+  }
+
+  #[test]
+  fn example_6() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      not_line_ending(input)
+    }
+
+    assert_eq!(parser("ab\r\nc"), Ok(("\r\nc", "ab")));
+    assert_eq!(parser("ab\nc"), Ok(("\nc", "ab")));
+    assert_eq!(parser("abc"), Ok(("", "abc")));
+    assert_eq!(parser(""), Ok(("", "")));
+    assert_eq!(
+      parser("a\rb\nc"),
+      Err(Err::Error(Error {
+        input: "a\rb\nc",
+        code: ErrorKind::Tag
+      }))
+    );
+    assert_eq!(
+      parser("a\rbc"),
+      Err(Err::Error(Error {
+        input: "a\rbc",
+        code: ErrorKind::Tag
+      }))
+    );
+  }
+
+  #[test]
+  fn example_7() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      line_ending(input)
+    }
+
+    assert_eq!(parser("\r\nc"), Ok(("c", "\r\n")));
+    assert_eq!(
+      parser("ab\r\nc"),
+      Err(Err::Error(Error::new("ab\r\nc", ErrorKind::CrLf)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::CrLf))));
+  }
+
+  #[test]
+  fn example_8() {
+    fn parser(input: &str) -> IResult<&str, char> {
+      newline(input)
+    }
+
+    assert_eq!(parser("\nc"), Ok(("c", '\n')));
+    assert_eq!(
+      parser("\r\nc"),
+      Err(Err::Error(Error::new("\r\nc", ErrorKind::Char)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+  }
+
+  #[test]
+  fn example_9() {
+    fn parser(input: &str) -> IResult<&str, char> {
+      tab(input)
+    }
+
+    assert_eq!(parser("\tc"), Ok(("c", '\t')));
+    assert_eq!(
+      parser("\r\nc"),
+      Err(Err::Error(Error::new("\r\nc", ErrorKind::Char)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Char))));
+  }
+
+  #[test]
+  fn example_10() {
+    fn parser(input: &str) -> IResult<&str, char> {
+      anychar(input)
+    }
+
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_11() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      alpha0(input)
+    }
+
+    assert_eq!(parser("ab1c"), Ok(("1c", "ab")));
+    assert_eq!(parser("1c"), Ok(("1c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_12() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      alpha1(input)
+    }
+
+    assert_eq!(parser("aB1c"), Ok(("1c", "aB")));
+    assert_eq!(
+      parser("1c"),
+      Err(Err::Error(Error::new("1c", ErrorKind::Alpha)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Alpha)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      digit0(input)
+    }
+
+    assert_eq!(parser("21c"), Ok(("c", "21")));
+    assert_eq!(parser("21"), Ok(("", "21")));
+    assert_eq!(parser("a21c"), Ok(("a21c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_14() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      digit1(input)
+    }
+
+    assert_eq!(parser("21c"), Ok(("c", "21")));
+    assert_eq!(
+      parser("c1"),
+      Err(Err::Error(Error::new("c1", ErrorKind::Digit)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Digit)))
+    );
+  }
+
+  #[test]
+  fn example_15() {
+    fn parser(input: &str) -> IResult<&str, u32> {
+      map_res(digit1, str::parse).parse(input)
+    }
+
+    assert_eq!(parser("416"), Ok(("", 416)));
+    assert_eq!(parser("12b"), Ok(("b", 12)));
+    assert!(parser("b").is_err());
+  }
+
+  #[test]
+  fn example_16() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      hex_digit0(input)
+    }
+
+    assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
+    assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_17() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      hex_digit1(input)
+    }
+
+    assert_eq!(parser("21cZ"), Ok(("Z", "21c")));
+    assert_eq!(
+      parser("H2"),
+      Err(Err::Error(Error::new("H2", ErrorKind::HexDigit)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::HexDigit)))
+    );
+  }
+
+  #[test]
+  fn example_18() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      oct_digit0(input)
+    }
+
+    assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
+    assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_19() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      oct_digit1(input)
+    }
+
+    assert_eq!(parser("21cZ"), Ok(("cZ", "21")));
+    assert_eq!(
+      parser("H2"),
+      Err(Err::Error(Error::new("H2", ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::OctDigit)))
+    );
+  }
+
+  #[test]
+  fn example_20() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      bin_digit0(input)
+    }
+
+    assert_eq!(parser("013a"), Ok(("3a", "01")));
+    assert_eq!(parser("a013"), Ok(("a013", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_21() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      bin_digit1(input)
+    }
+
+    assert_eq!(parser("013a"), Ok(("3a", "01")));
+    assert_eq!(
+      parser("a013"),
+      Err(Err::Error(Error::new("a013", ErrorKind::BinDigit)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::BinDigit)))
+    );
+  }
+
+  #[test]
+  fn example_22() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      alphanumeric0(input)
+    }
+
+    assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
+    assert_eq!(parser("&Z21c"), Ok(("&Z21c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_23() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      alphanumeric1(input)
+    }
+
+    assert_eq!(parser("21cZ%1"), Ok(("%1", "21cZ")));
+    assert_eq!(
+      parser("&H2"),
+      Err(Err::Error(Error::new("&H2", ErrorKind::AlphaNumeric)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::AlphaNumeric)))
+    );
+  }
+
+  #[test]
+  fn example_24() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      space0(input)
+    }
+
+    assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
+    assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_25() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      space1(input)
+    }
+
+    assert_eq!(parser(" \t21c"), Ok(("21c", " \t")));
+    assert_eq!(
+      parser("H2"),
+      Err(Err::Error(Error::new("H2", ErrorKind::Space)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Space)))
+    );
+  }
+
+  #[test]
+  fn example_26() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      multispace0(input)
+    }
+
+    assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+    assert_eq!(parser("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_27() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      multispace1(input)
+    }
+
+    assert_eq!(parser(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
+    assert_eq!(
+      parser("H2"),
+      Err(Err::Error(Error::new("H2", ErrorKind::MultiSpace)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::MultiSpace)))
+    );
+  }
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -48,12 +48,7 @@ pub fn is_oct_digit(chr: u8) -> bool {
 ///
 /// # Example
 ///
-/// ```
-/// # use nom::character::is_bin_digit;
-/// assert_eq!(is_bin_digit(b'a'), false);
-/// assert_eq!(is_bin_digit(b'2'), false);
-/// assert_eq!(is_bin_digit(b'0'), true);
-/// assert_eq!(is_bin_digit(b'1'), true);
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[inline]
 pub fn is_bin_digit(chr: u8) -> bool {
@@ -85,15 +80,7 @@ pub fn is_newline(chr: u8) -> bool {
 ///
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::character::streaming::char;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     char('a')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn char<I, Error: ParseError<I>>(c: char) -> impl Parser<I, Output = char, Error = Error>
 where
@@ -142,15 +129,7 @@ where
 ///
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::character::complete::satisfy;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     satisfy(|c| c == 'a' || c == 'b')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Satisfy))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn satisfy<F, I, Error: ParseError<I>>(
   predicate: F,
@@ -209,12 +188,7 @@ where
 ///
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind};
-/// # use nom::character::complete::one_of;
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (&str, ErrorKind)>("a")(""), Err(Err::Error(("", ErrorKind::OneOf))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl Parser<I, Output = char, Error = Error>
 where
@@ -232,12 +206,7 @@ where
 ///
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::character::streaming::none_of;
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::Unknown)));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl Parser<I, Output = char, Error = Error>
 where
@@ -256,14 +225,7 @@ where
 ///
 /// # Example
 ///
-/// ```
-/// # use nom::{character::complete::anychar, Err, error::{Error, ErrorKind}, IResult};
-/// fn parser(input: &str) -> IResult<&str, char> {
-///     anychar(input)
-/// }
-///
-/// assert_eq!(parser("abc"), Ok(("bc",'a')));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
@@ -315,12 +277,7 @@ where
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::digit1;
-/// assert_eq!(digit1::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit1::<_, (_, ErrorKind)>("c1"), Err(Err::Error(("c1", ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn digit1<T, E: ParseError<T>>() -> impl Parser<T, Output = T, Error = E>
 where
@@ -358,12 +315,7 @@ where
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::multispace0;
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 pub fn multispace0<T, E: ParseError<T>>() -> impl Parser<T, Output = T, Error = E>
 where
@@ -398,5 +350,118 @@ where
       let c = item.as_char();
       !(c == ' ' || c == '\t' || c == '\r' || c == '\n')
     })
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::character::complete::{anychar, one_of, satisfy};
+  use nom::character::is_bin_digit;
+  use nom::character::streaming::*;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult, Needed,
+  };
+
+  #[test]
+  fn example_1() {
+    assert_eq!(is_bin_digit(b'a'), false);
+    assert_eq!(is_bin_digit(b'2'), false);
+    assert_eq!(is_bin_digit(b'0'), true);
+    assert_eq!(is_bin_digit(b'1'), true);
+  }
+
+  #[test]
+  fn example_2() {
+    fn parser(i: &str) -> IResult<&str, char> {
+      char('a')(i)
+    }
+
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      parser("bc"),
+      Err(Err::Error(Error::new("bc", ErrorKind::Char)))
+    );
+    assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_3() {
+    fn parser(i: &str) -> IResult<&str, char> {
+      satisfy(|c| c == 'a' || c == 'b')(i)
+    }
+
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      parser("cd"),
+      Err(Err::Error(Error::new("cd", ErrorKind::Satisfy)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Satisfy)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    assert_eq!(one_of::<_, _, (&str, ErrorKind)>("abc")("b"), Ok(("", 'b')));
+    assert_eq!(
+      one_of::<_, _, (&str, ErrorKind)>("a")("bc"),
+      Err(Err::Error(("bc", ErrorKind::OneOf)))
+    );
+    assert_eq!(
+      one_of::<_, _, (&str, ErrorKind)>("a")(""),
+      Err(Err::Error(("", ErrorKind::OneOf)))
+    );
+  }
+
+  #[test]
+  fn example_5() {
+    assert_eq!(none_of::<_, _, (_, ErrorKind)>("abc")("z"), Ok(("", 'z')));
+    assert_eq!(
+      none_of::<_, _, (_, ErrorKind)>("ab")("a"),
+      Err(Err::Error(("a", ErrorKind::NoneOf)))
+    );
+    assert_eq!(
+      none_of::<_, _, (_, ErrorKind)>("a")(""),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+  }
+
+  #[test]
+  fn example_6() {
+    fn parser(input: &str) -> IResult<&str, char> {
+      anychar(input)
+    }
+
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_7() {
+    assert_eq!(digit1::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
+    assert_eq!(
+      digit1::<_, (_, ErrorKind)>("c1"),
+      Err(Err::Error(("c1", ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_8() {
+    assert_eq!(
+      multispace0::<_, (_, ErrorKind)>(" \t\n\r21c"),
+      Ok(("21c", " \t\n\r"))
+    );
+    assert_eq!(multispace0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(
+      multispace0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
   }
 }

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -771,7 +771,7 @@ mod tests {
   use crate::sequence::pair;
   use crate::traits::ParseTo;
   use crate::Parser;
-  use proptest::prelude::*;
+  //use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -1238,19 +1238,19 @@ mod tests {
     }
   }
 
-  proptest! {
-    #[test]
-    fn ints(s in "\\PC*") {
-        let res1 = digit_to_i16(&s);
-        let res2 = i16(s.as_str());
-        assert_eq!(res1, res2);
-    }
+  // proptest! {
+  //   #[test]
+  //   fn ints(s in "\\PC*") {
+  //       let res1 = digit_to_i16(&s);
+  //       let res2 = i16(s.as_str());
+  //       assert_eq!(res1, res2);
+  //   }
 
-    #[test]
-    fn uints(s in "\\PC*") {
-        let res1 = digit_to_u32(&s);
-        let res2 = u32(s.as_str());
-        assert_eq!(res1, res2);
-    }
-  }
+  //   #[test]
+  //   fn uints(s in "\\PC*") {
+  //       let res1 = digit_to_u32(&s);
+  //       let res2 = u32(s.as_str());
+  //       assert_eq!(res1, res2);
+  //   }
+  // }
 }

--- a/src/character/streaming.rs
+++ b/src/character/streaming.rs
@@ -19,15 +19,7 @@ use crate::Streaming;
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::character::streaming::char;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     char('a')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("bc"), Err(Err::Error(Error::new("bc", ErrorKind::Char))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn char<I, Error: ParseError<I>>(c: char) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -43,15 +35,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{ErrorKind, Error}, Needed, IResult};
-/// # use nom::character::streaming::satisfy;
-/// fn parser(i: &str) -> IResult<&str, char> {
-///     satisfy(|c| c == 'a' || c == 'b')(i)
-/// }
-/// assert_eq!(parser("abc"), Ok(("bc", 'a')));
-/// assert_eq!(parser("cd"), Err(Err::Error(Error::new("cd", ErrorKind::Satisfy))));
-/// assert_eq!(parser(""), Err(Err::Incomplete(Needed::Unknown)));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn satisfy<F, I, Error: ParseError<I>>(cond: F) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -68,12 +52,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::character::streaming::one_of;
-/// assert_eq!(one_of::<_, _, (_, ErrorKind)>("abc")("b"), Ok(("", 'b')));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")("bc"), Err(Err::Error(("bc", ErrorKind::OneOf))));
-/// assert_eq!(one_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::Unknown)));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn one_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -90,12 +69,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::character::streaming::none_of;
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("abc")("z"), Ok(("", 'z')));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("ab")("a"), Err(Err::Error(("a", ErrorKind::NoneOf))));
-/// assert_eq!(none_of::<_, _, (_, ErrorKind)>("a")(""), Err(Err::Incomplete(Needed::Unknown)));
+/// ```rust,{source="doctests:;example_4"},ignore
 /// ```
 pub fn none_of<I, T, Error: ParseError<I>>(list: T) -> impl FnMut(I) -> IResult<I, char, Error>
 where
@@ -112,12 +86,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::crlf;
-/// assert_eq!(crlf::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(crlf::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(crlf::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn crlf<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -140,14 +109,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Needed};
-/// # use nom::character::streaming::not_line_ending;
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Ok(("\r\nc", "ab")));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("abc"), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::Unknown)));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("a\rb\nc"), Err(Err::Error(("a\rb\nc", ErrorKind::Tag ))));
-/// assert_eq!(not_line_ending::<_, (_, ErrorKind)>("a\rbc"), Err(Err::Error(("a\rbc", ErrorKind::Tag ))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn not_line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -187,12 +149,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::line_ending;
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>("ab\r\nc"), Err(Err::Error(("ab\r\nc", ErrorKind::CrLf))));
-/// assert_eq!(line_ending::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn line_ending<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -218,12 +175,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::newline;
-/// assert_eq!(newline::<_, (_, ErrorKind)>("\nc"), Ok(("c", '\n')));
-/// assert_eq!(newline::<_, (_, ErrorKind)>("\r\nc"), Err(Err::Error(("\r\nc", ErrorKind::Char))));
-/// assert_eq!(newline::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 pub fn newline<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
@@ -238,12 +190,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::tab;
-/// assert_eq!(tab::<_, (_, ErrorKind)>("\tc"), Ok(("c", '\t')));
-/// assert_eq!(tab::<_, (_, ErrorKind)>("\r\nc"), Err(Err::Error(("\r\nc", ErrorKind::Char))));
-/// assert_eq!(tab::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 pub fn tab<I, Error: ParseError<I>>(input: I) -> IResult<I, char, Error>
 where
@@ -258,10 +205,7 @@ where
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there's not enough input data.
 /// # Example
 ///
-/// ```
-/// # use nom::{character::streaming::anychar, Err, error::ErrorKind, IResult, Needed};
-/// assert_eq!(anychar::<_, (_, ErrorKind)>("abc"), Ok(("bc",'a')));
-/// assert_eq!(anychar::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 pub fn anychar<T, E: ParseError<T>>(input: T) -> IResult<T, char, E>
 where
@@ -281,12 +225,7 @@ where
 /// or if no terminating token is found (a non alphabetic character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::alpha0;
-/// assert_eq!(alpha0::<_, (_, ErrorKind)>("ab1c"), Ok(("1c", "ab")));
-/// assert_eq!(alpha0::<_, (_, ErrorKind)>("1c"), Ok(("1c", "")));
-/// assert_eq!(alpha0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn alpha0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -302,12 +241,7 @@ where
 /// or if no terminating token is found (a non alphabetic character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::alpha1;
-/// assert_eq!(alpha1::<_, (_, ErrorKind)>("aB1c"), Ok(("1c", "aB")));
-/// assert_eq!(alpha1::<_, (_, ErrorKind)>("1c"), Err(Err::Error(("1c", ErrorKind::Alpha))));
-/// assert_eq!(alpha1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn alpha1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -323,12 +257,7 @@ where
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::digit0;
-/// assert_eq!(digit0::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit0::<_, (_, ErrorKind)>("a21c"), Ok(("a21c", "")));
-/// assert_eq!(digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 pub fn digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -344,12 +273,7 @@ where
 /// or if no terminating token is found (a non digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::digit1;
-/// assert_eq!(digit1::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
-/// assert_eq!(digit1::<_, (_, ErrorKind)>("c1"), Err(Err::Error(("c1", ErrorKind::Digit))));
-/// assert_eq!(digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 pub fn digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -365,12 +289,7 @@ where
 /// or if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::hex_digit0;
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind)>("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(hex_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 pub fn hex_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -386,12 +305,7 @@ where
 /// or if no terminating token is found (a non hexadecimal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::hex_digit1;
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind)>("21cZ"), Ok(("Z", "21c")));
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::HexDigit))));
-/// assert_eq!(hex_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="example_16"},ignore
 /// ```
 pub fn hex_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -407,12 +321,7 @@ where
 /// or if no terminating token is found (a non octal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::oct_digit0;
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind)>("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(oct_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 pub fn oct_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -428,12 +337,7 @@ where
 /// or if no terminating token is found (a non octal digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::oct_digit1;
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind)>("21cZ"), Ok(("cZ", "21")));
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::OctDigit))));
-/// assert_eq!(oct_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 pub fn oct_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -449,12 +353,7 @@ where
 /// or if no terminating token is found (a non binary digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::bin_digit0;
-/// assert_eq!(bin_digit0::<_, (_, ErrorKind)>("013a"), Ok(("3a", "01")));
-/// assert_eq!(bin_digit0::<_, (_, ErrorKind)>("a013"), Ok(("a013", "")));
-/// assert_eq!(bin_digit0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 pub fn bin_digit0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -470,12 +369,7 @@ where
 /// or if no terminating token is found (a non binary digit character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::bin_digit1;
-/// assert_eq!(bin_digit1::<_, (_, ErrorKind)>("013a"), Ok(("3a", "01")));
-/// assert_eq!(bin_digit1::<_, (_, ErrorKind)>("a013"), Err(Err::Error(("a013", ErrorKind::BinDigit))));
-/// assert_eq!(bin_digit1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 pub fn bin_digit1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -491,12 +385,7 @@ where
 /// or if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::alphanumeric0;
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>("&Z21c"), Ok(("&Z21c", "")));
-/// assert_eq!(alphanumeric0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_21"},ignore
 /// ```
 pub fn alphanumeric0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -512,12 +401,7 @@ where
 /// or if no terminating token is found (a non alphanumerical character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::alphanumeric1;
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>("21cZ%1"), Ok(("%1", "21cZ")));
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>("&H2"), Err(Err::Error(("&H2", ErrorKind::AlphaNumeric))));
-/// assert_eq!(alphanumeric1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_22"},ignore
 /// ```
 pub fn alphanumeric1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -533,12 +417,7 @@ where
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::space0;
-/// assert_eq!(space0::<_, (_, ErrorKind)>(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(space0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(space0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_23"},ignore
 /// ```
 pub fn space0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -556,12 +435,7 @@ where
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::space1;
-/// assert_eq!(space1::<_, (_, ErrorKind)>(" \t21c"), Ok(("21c", " \t")));
-/// assert_eq!(space1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::Space))));
-/// assert_eq!(space1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_24"},ignore
 /// ```
 pub fn space1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -583,12 +457,7 @@ where
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::multispace0;
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
-/// assert_eq!(multispace0::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_25"},ignore
 /// ```
 pub fn multispace0<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -607,12 +476,7 @@ where
 /// or if no terminating token is found (a non space character).
 /// # Example
 ///
-/// ```
-/// # use nom::{Err, error::ErrorKind, IResult, Needed};
-/// # use nom::character::streaming::multispace1;
-/// assert_eq!(multispace1::<_, (_, ErrorKind)>(" \t\n\r21c"), Ok(("21c", " \t\n\r")));
-/// assert_eq!(multispace1::<_, (_, ErrorKind)>("H2"), Err(Err::Error(("H2", ErrorKind::MultiSpace))));
-/// assert_eq!(multispace1::<_, (_, ErrorKind)>(""), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_26"},ignore
 /// ```
 pub fn multispace1<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
 where
@@ -1253,4 +1117,352 @@ mod tests {
   //       assert_eq!(res1, res2);
   //   }
   // }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::character::streaming::*;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult, Needed,
+  };
+
+  #[test]
+  fn example_1() {
+    fn parser(i: &str) -> IResult<&str, char> {
+      char('a')(i)
+    }
+
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      parser("bc"),
+      Err(Err::Error(Error::new("bc", ErrorKind::Char)))
+    );
+    assert_eq!(parser(""), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_2() {
+    fn parser(i: &str) -> IResult<&str, char> {
+      satisfy(|c| c == 'a' || c == 'b')(i)
+    }
+
+    assert_eq!(parser("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      parser("cd"),
+      Err(Err::Error(Error::new("cd", ErrorKind::Satisfy)))
+    );
+    assert_eq!(parser(""), Err(Err::Incomplete(Needed::Unknown)));
+  }
+
+  #[test]
+  fn example_3() {
+    assert_eq!(one_of::<_, _, (_, ErrorKind)>("abc")("b"), Ok(("", 'b')));
+    assert_eq!(
+      one_of::<_, _, (_, ErrorKind)>("a")("bc"),
+      Err(Err::Error(("bc", ErrorKind::OneOf)))
+    );
+    assert_eq!(
+      one_of::<_, _, (_, ErrorKind)>("a")(""),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    assert_eq!(none_of::<_, _, (_, ErrorKind)>("abc")("z"), Ok(("", 'z')));
+    assert_eq!(
+      none_of::<_, _, (_, ErrorKind)>("ab")("a"),
+      Err(Err::Error(("a", ErrorKind::NoneOf)))
+    );
+    assert_eq!(
+      none_of::<_, _, (_, ErrorKind)>("a")(""),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+  }
+
+  #[test]
+  fn example_5() {
+    assert_eq!(crlf::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
+    assert_eq!(
+      crlf::<_, (_, ErrorKind)>("ab\r\nc"),
+      Err(Err::Error(("ab\r\nc", ErrorKind::CrLf)))
+    );
+    assert_eq!(
+      crlf::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(2)))
+    );
+  }
+
+  #[test]
+  fn example_6() {
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind)>("ab\r\nc"),
+      Ok(("\r\nc", "ab"))
+    );
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind)>("abc"),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::Unknown))
+    );
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind)>("a\rb\nc"),
+      Err(Err::Error(("a\rb\nc", ErrorKind::Tag)))
+    );
+    assert_eq!(
+      not_line_ending::<_, (_, ErrorKind)>("a\rbc"),
+      Err(Err::Error(("a\rbc", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_7() {
+    assert_eq!(line_ending::<_, (_, ErrorKind)>("\r\nc"), Ok(("c", "\r\n")));
+    assert_eq!(
+      line_ending::<_, (_, ErrorKind)>("ab\r\nc"),
+      Err(Err::Error(("ab\r\nc", ErrorKind::CrLf)))
+    );
+    assert_eq!(
+      line_ending::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_8() {
+    assert_eq!(newline::<_, (_, ErrorKind)>("\nc"), Ok(("c", '\n')));
+    assert_eq!(
+      newline::<_, (_, ErrorKind)>("\r\nc"),
+      Err(Err::Error(("\r\nc", ErrorKind::Char)))
+    );
+    assert_eq!(
+      newline::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_9() {
+    assert_eq!(tab::<_, (_, ErrorKind)>("\tc"), Ok(("c", '\t')));
+    assert_eq!(
+      tab::<_, (_, ErrorKind)>("\r\nc"),
+      Err(Err::Error(("\r\nc", ErrorKind::Char)))
+    );
+    assert_eq!(
+      tab::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_10() {
+    assert_eq!(anychar::<_, (_, ErrorKind)>("abc"), Ok(("bc", 'a')));
+    assert_eq!(
+      anychar::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_11() {
+    assert_eq!(alpha0::<_, (_, ErrorKind)>("ab1c"), Ok(("1c", "ab")));
+    assert_eq!(alpha0::<_, (_, ErrorKind)>("1c"), Ok(("1c", "")));
+    assert_eq!(
+      alpha0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_12() {
+    assert_eq!(alpha1::<_, (_, ErrorKind)>("aB1c"), Ok(("1c", "aB")));
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind)>("1c"),
+      Err(Err::Error(("1c", ErrorKind::Alpha)))
+    );
+    assert_eq!(
+      alpha1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    assert_eq!(digit0::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
+    assert_eq!(digit0::<_, (_, ErrorKind)>("a21c"), Ok(("a21c", "")));
+    assert_eq!(
+      digit0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_14() {
+    assert_eq!(digit1::<_, (_, ErrorKind)>("21c"), Ok(("c", "21")));
+    assert_eq!(
+      digit1::<_, (_, ErrorKind)>("c1"),
+      Err(Err::Error(("c1", ErrorKind::Digit)))
+    );
+    assert_eq!(
+      digit1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_15() {
+    assert_eq!(hex_digit0::<_, (_, ErrorKind)>("21cZ"), Ok(("Z", "21c")));
+    assert_eq!(hex_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(
+      hex_digit0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_16() {
+    assert_eq!(hex_digit1::<_, (_, ErrorKind)>("21cZ"), Ok(("Z", "21c")));
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind)>("H2"),
+      Err(Err::Error(("H2", ErrorKind::HexDigit)))
+    );
+    assert_eq!(
+      hex_digit1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_17() {
+    assert_eq!(oct_digit0::<_, (_, ErrorKind)>("21cZ"), Ok(("cZ", "21")));
+    assert_eq!(oct_digit0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(
+      oct_digit0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_18() {
+    assert_eq!(oct_digit1::<_, (_, ErrorKind)>("21cZ"), Ok(("cZ", "21")));
+    assert_eq!(
+      oct_digit1::<_, (_, ErrorKind)>("H2"),
+      Err(Err::Error(("H2", ErrorKind::OctDigit)))
+    );
+    assert_eq!(
+      oct_digit1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_19() {
+    assert_eq!(bin_digit0::<_, (_, ErrorKind)>("013a"), Ok(("3a", "01")));
+    assert_eq!(bin_digit0::<_, (_, ErrorKind)>("a013"), Ok(("a013", "")));
+    assert_eq!(
+      bin_digit0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_20() {
+    assert_eq!(bin_digit1::<_, (_, ErrorKind)>("013a"), Ok(("3a", "01")));
+    assert_eq!(
+      bin_digit1::<_, (_, ErrorKind)>("a013"),
+      Err(Err::Error(("a013", ErrorKind::BinDigit)))
+    );
+    assert_eq!(
+      bin_digit1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_21() {
+    assert_eq!(
+      alphanumeric0::<_, (_, ErrorKind)>("21cZ%1"),
+      Ok(("%1", "21cZ"))
+    );
+    assert_eq!(
+      alphanumeric0::<_, (_, ErrorKind)>("&Z21c"),
+      Ok(("&Z21c", ""))
+    );
+    assert_eq!(
+      alphanumeric0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_22() {
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind)>("21cZ%1"),
+      Ok(("%1", "21cZ"))
+    );
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind)>("&H2"),
+      Err(Err::Error(("&H2", ErrorKind::AlphaNumeric)))
+    );
+    assert_eq!(
+      alphanumeric1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_23() {
+    assert_eq!(space0::<_, (_, ErrorKind)>(" \t21c"), Ok(("21c", " \t")));
+    assert_eq!(space0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(
+      space0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_24() {
+    assert_eq!(space1::<_, (_, ErrorKind)>(" \t21c"), Ok(("21c", " \t")));
+    assert_eq!(
+      space1::<_, (_, ErrorKind)>("H2"),
+      Err(Err::Error(("H2", ErrorKind::Space)))
+    );
+    assert_eq!(
+      space1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_25() {
+    assert_eq!(
+      multispace0::<_, (_, ErrorKind)>(" \t\n\r21c"),
+      Ok(("21c", " \t\n\r"))
+    );
+    assert_eq!(multispace0::<_, (_, ErrorKind)>("Z21c"), Ok(("Z21c", "")));
+    assert_eq!(
+      multispace0::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
+
+  #[test]
+  fn example_26() {
+    assert_eq!(
+      multispace1::<_, (_, ErrorKind)>(" \t\n\r21c"),
+      Ok(("21c", " \t\n\r"))
+    );
+    assert_eq!(
+      multispace1::<_, (_, ErrorKind)>("H2"),
+      Err(Err::Error(("H2", ErrorKind::MultiSpace)))
+    );
+    assert_eq!(
+      multispace1::<_, (_, ErrorKind)>(""),
+      Err(Err::Incomplete(Needed::new(1)))
+    );
+  }
 }

--- a/src/combinator/mod.rs
+++ b/src/combinator/mod.rs
@@ -23,11 +23,7 @@ mod tests;
 
 /// Return the remaining input.
 ///
-/// ```rust
-/// # use nom::error::ErrorKind;
-/// use nom::combinator::rest;
-/// assert_eq!(rest::<_,(_, ErrorKind)>("abc"), Ok(("", "abc")));
-/// assert_eq!(rest::<_,(_, ErrorKind)>(""), Ok(("", "")));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[inline]
 pub fn rest<T, E: ParseError<T>>(input: T) -> IResult<T, T, E>
@@ -39,11 +35,7 @@ where
 
 /// Return the length of the remaining input.
 ///
-/// ```rust
-/// # use nom::error::ErrorKind;
-/// use nom::combinator::rest_len;
-/// assert_eq!(rest_len::<_,(_, ErrorKind)>("abc"), Ok(("abc", 3)));
-/// assert_eq!(rest_len::<_,(_, ErrorKind)>(""), Ok(("", 0)));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 #[inline]
 pub fn rest_len<T, E: ParseError<T>>(input: T) -> IResult<T, usize, E>
@@ -56,20 +48,7 @@ where
 
 /// Maps a function on the result of a parser.
 ///
-/// ```rust
-/// use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::character::complete::digit1;
-/// use nom::combinator::map;
-/// # fn main() {
-///
-/// let mut parser = map(digit1, |s: &str| s.len());
-///
-/// // the parser will count how many characters were returned by digit1
-/// assert_eq!(parser.parse("123456"), Ok(("", 6)));
-///
-/// // this will fail if digit1 fails
-/// assert_eq!(parser.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
-/// # }
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn map<I, O, E: ParseError<I>, F, G>(parser: F, f: G) -> impl Parser<I, Output = O, Error = E>
 where
@@ -81,23 +60,7 @@ where
 
 /// Applies a function returning a `Result` over the result of a parser.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::character::complete::digit1;
-/// use nom::combinator::map_res;
-/// # fn main() {
-///
-/// let mut parse = map_res(digit1, |s: &str| s.parse::<u8>());
-///
-/// // the parser will convert the result of digit1 to a number
-/// assert_eq!(parse.parse("123"), Ok(("", 123)));
-///
-/// // this will fail if digit1 fails
-/// assert_eq!(parse.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
-///
-/// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse.parse("123456"), Err(Err::Error(("123456", ErrorKind::MapRes))));
-/// # }
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn map_res<I: Clone, O, E: ParseError<I> + FromExternalError<I, E2>, E2, F, G>(
   parser: F,
@@ -112,23 +75,7 @@ where
 
 /// Applies a function returning an `Option` over the result of a parser.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::character::complete::digit1;
-/// use nom::combinator::map_opt;
-/// # fn main() {
-///
-/// let mut parse = map_opt(digit1, |s: &str| s.parse::<u8>().ok());
-///
-/// // the parser will convert the result of digit1 to a number
-/// assert_eq!(parse.parse("123"), Ok(("", 123)));
-///
-/// // this will fail if digit1 fails
-/// assert_eq!(parse.parse("abc"), Err(Err::Error(("abc", ErrorKind::Digit))));
-///
-/// // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
-/// assert_eq!(parse.parse("123456"), Err(Err::Error(("123456", ErrorKind::MapOpt))));
-/// # }
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn map_opt<I: Clone, O, E: ParseError<I>, F, G>(
   parser: F,
@@ -143,19 +90,7 @@ where
 
 /// Applies a parser over the result of another one.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::character::complete::digit1;
-/// use nom::bytes::complete::take;
-/// use nom::combinator::map_parser;
-/// # fn main() {
-///
-/// let mut parse = map_parser(take(5u8), digit1);
-///
-/// assert_eq!(parse.parse("12345"), Ok(("", "12345")));
-/// assert_eq!(parse.parse("123ab"), Ok(("", "123")));
-/// assert_eq!(parse.parse("123"), Err(Err::Error(("123", ErrorKind::Eof))));
-/// # }
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 pub fn map_parser<I, O, E: ParseError<I>, F, G>(
   parser: F,
@@ -170,18 +105,7 @@ where
 
 /// Creates a new parser from the output of the first parser, then apply that parser over the rest of the input.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::bytes::complete::take;
-/// use nom::number::complete::u8;
-/// use nom::combinator::flat_map;
-/// # fn main() {
-///
-/// let mut parse = flat_map(u8, take);
-///
-/// assert_eq!(parse.parse(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
-/// assert_eq!(parse.parse(&[4, 0, 1, 2][..]), Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof))));
-/// # }
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn flat_map<I, O, E: ParseError<I>, F, G, H>(
   parser: F,
@@ -199,19 +123,7 @@ where
 ///
 /// To chain an error up, see [`cut`].
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::opt;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// fn parser(i: &str) -> IResult<&str, Option<&str>> {
-///   opt(alpha1).parse(i)
-/// }
-///
-/// assert_eq!(parser("abcd;"), Ok((";", Some("abcd"))));
-/// assert_eq!(parser("123;"), Ok(("123;", None)));
-/// # }
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 pub fn opt<I: Clone, E: ParseError<I>, F>(
   f: F,
@@ -252,21 +164,7 @@ where
 
 /// Calls the parser if the condition is met.
 ///
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, IResult, Parser};
-/// use nom::combinator::cond;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// fn parser(b: bool, i: &str) -> IResult<&str, Option<&str>> {
-///   cond(b, alpha1).parse(i)
-/// }
-///
-/// assert_eq!(parser(true, "abcd;"), Ok((";", Some("abcd"))));
-/// assert_eq!(parser(false, "abcd;"), Ok(("abcd;", None)));
-/// assert_eq!(parser(true, "123;"), Err(Err::Error(Error::new("123;", ErrorKind::Alpha))));
-/// assert_eq!(parser(false, "123;"), Ok(("123;", None)));
-/// # }
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 pub fn cond<I, E: ParseError<I>, F>(
   b: bool,
@@ -304,17 +202,7 @@ where
 
 /// Tries to apply its parser without consuming the input.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::peek;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// let mut parser = peek(alpha1);
-///
-/// assert_eq!(parser.parse("abcd;"), Ok(("abcd;", "abcd")));
-/// assert_eq!(parser.parse("123;"), Err(Err::Error(("123;", ErrorKind::Alpha))));
-/// # }
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 pub fn peek<I: Clone, F>(
   parser: F,
@@ -352,16 +240,7 @@ where
 /// When we're at the end of the data, this combinator
 /// will succeed
 ///
-/// ```
-/// # use std::str;
-/// # use nom::{Err, error::ErrorKind, IResult};
-/// # use nom::combinator::eof;
-///
-/// # fn main() {
-/// let parser = eof;
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Eof))));
-/// assert_eq!(parser(""), Ok(("", "")));
-/// # }
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn eof<I: Input + Clone, E: ParseError<I>>(input: I) -> IResult<I, I, E> {
   if input.input_len() == 0 {
@@ -374,17 +253,7 @@ pub fn eof<I: Input + Clone, E: ParseError<I>>(input: I) -> IResult<I, I, E> {
 
 /// Transforms Incomplete into `Error`.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::bytes::streaming::take;
-/// use nom::combinator::complete;
-/// # fn main() {
-///
-/// let mut parser = complete(take(5u8));
-///
-/// assert_eq!(parser.parse("abcdefg"), Ok(("fg", "abcde")));
-/// assert_eq!(parser.parse("abcd"), Err(Err::Error(("abcd", ErrorKind::Complete))));
-/// # }
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn complete<I: Clone, O, E: ParseError<I>, F>(
   parser: F,
@@ -426,18 +295,7 @@ where
 
 /// Succeeds if all the input has been consumed by its child parser.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::all_consuming;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// let mut parser = all_consuming(alpha1);
-///
-/// assert_eq!(parser.parse("abcd"), Ok(("", "abcd")));
-/// assert_eq!(parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Eof))));
-/// assert_eq!(parser.parse("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
-/// # }
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 pub fn all_consuming<I, E: ParseError<I>, F>(
   parser: F,
@@ -479,18 +337,7 @@ where
 /// The verification function takes as argument a reference to the output of the
 /// parser.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::verify;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// let mut parser = verify(alpha1, |s: &str| s.len() == 4);
-///
-/// assert_eq!(parser.parse("abcd"), Ok(("", "abcd")));
-/// assert_eq!(parser.parse("abcde"), Err(Err::Error(("abcde", ErrorKind::Verify))));
-/// assert_eq!(parser.parse("123abcd;"),Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
-/// # }
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 pub fn verify<I: Clone, O2, E: ParseError<I>, F, G>(
   first: F,
@@ -545,17 +392,7 @@ where
 
 /// Returns the provided value if the child parser succeeds.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::value;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// let mut parser = value(1234, alpha1);
-///
-/// assert_eq!(parser.parse("abcd"), Ok(("", 1234)));
-/// assert_eq!(parser.parse("123abcd;"), Err(Err::Error(("123abcd;", ErrorKind::Alpha))));
-/// # }
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 pub fn value<I, O1: Clone, E: ParseError<I>, F>(
   val: O1,
@@ -569,17 +406,7 @@ where
 
 /// Succeeds if the child parser returns an error.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::not;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// let mut parser = not(alpha1);
-///
-/// assert_eq!(parser.parse("123"), Ok(("123", ())));
-/// assert_eq!(parser.parse("abcd"), Err(Err::Error(("abcd", ErrorKind::Not))));
-/// # }
+/// ```rust,{source="doctests::example_16"},ignore
 /// ```
 pub fn not<I: Clone, E: ParseError<I>, F>(parser: F) -> impl Parser<I, Output = (), Error = E>
 where
@@ -615,18 +442,7 @@ where
 
 /// If the child parser was successful, return the consumed input as produced value.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::recognize;
-/// use nom::character::complete::{char, alpha1};
-/// use nom::sequence::separated_pair;
-/// # fn main() {
-///
-/// let mut parser = recognize(separated_pair(alpha1, char(','), alpha1));
-///
-/// assert_eq!(parser.parse("abcd,efgh"), Ok(("", "abcd,efgh")));
-/// assert_eq!(parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
-/// # }
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 pub fn recognize<I: Clone + Offset + Input, E: ParseError<I>, F>(
   parser: F,
@@ -675,33 +491,7 @@ where
 ///
 /// Returned tuple is of the format `(consumed input, produced output)`.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::combinator::{consumed, value, recognize, map};
-/// use nom::character::complete::{char, alpha1};
-/// use nom::bytes::complete::tag;
-/// use nom::sequence::separated_pair;
-///
-/// fn inner_parser(input: &str) -> IResult<&str, bool> {
-///     value(true, tag("1234")).parse(input)
-/// }
-///
-/// # fn main() {
-///
-/// let mut consumed_parser = consumed(value(true, separated_pair(alpha1, char(','), alpha1)));
-///
-/// assert_eq!(consumed_parser.parse("abcd,efgh1"), Ok(("1", ("abcd,efgh", true))));
-/// assert_eq!(consumed_parser.parse("abcd;"),Err(Err::Error((";", ErrorKind::Char))));
-///
-///
-/// // the first output (representing the consumed input)
-/// // should be the same as that of the `recognize` parser.
-/// let mut recognize_parser = recognize(inner_parser);
-/// let mut consumed_parser = map(consumed(inner_parser), |(consumed, output)| consumed);
-///
-/// assert_eq!(recognize_parser.parse("1234"), consumed_parser.parse("1234"));
-/// assert_eq!(recognize_parser.parse("abcd"), consumed_parser.parse("abcd"));
-/// # }
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 pub fn consumed<I, F, E>(
   parser: F,
@@ -755,48 +545,11 @@ where
 /// # Example
 ///
 /// Without `cut`:
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// # use nom::character::complete::{one_of, digit1};
-/// # use nom::combinator::rest;
-/// # use nom::branch::alt;
-/// # use nom::sequence::preceded;
-/// # fn main() {
-///
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///   alt((
-///     preceded(one_of("+-"), digit1),
-///     rest
-///   )).parse(input)
-/// }
-///
-/// assert_eq!(parser("+10 ab"), Ok((" ab", "10")));
-/// assert_eq!(parser("ab"), Ok(("", "ab")));
-/// assert_eq!(parser("+"), Ok(("", "+")));
-/// # }
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 ///
 /// With `cut`:
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser, error::Error};
-/// # use nom::character::complete::{one_of, digit1};
-/// # use nom::combinator::rest;
-/// # use nom::branch::alt;
-/// # use nom::sequence::preceded;
-/// use nom::combinator::cut;
-/// # fn main() {
-///
-/// fn parser(input: &str) -> IResult<&str, &str> {
-///   alt((
-///     preceded(one_of("+-"), cut(digit1)),
-///     rest
-///   )).parse(input)
-/// }
-///
-/// assert_eq!(parser("+10 ab"), Ok((" ab", "10")));
-/// assert_eq!(parser("ab"), Ok(("", "ab")));
-/// assert_eq!(parser("+"), Err(Err::Failure(Error { input: "", code: ErrorKind::Digit })));
-/// # }
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 pub fn cut<I, E: ParseError<I>, F>(
   parser: F,
@@ -839,22 +592,7 @@ where
 /// it will be able to convert the output value and the error value
 /// as long as the `Into` implementations are available
 ///
-/// ```rust
-/// # use nom::{IResult, Parser};
-/// use nom::combinator::into;
-/// use nom::character::complete::alpha1;
-/// # fn main() {
-///
-/// fn parser1(i: &str) -> IResult<&str, &str> {
-///   alpha1(i)
-/// }
-///
-/// let mut parser2 = into(parser1);
-///
-/// // the parser converts the &str output of the child parser into a Vec<u8>
-/// let bytes: IResult<&str, Vec<u8>> = parser2.parse("abcd");
-/// assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
-/// # }
+/// ```rust,{source="doctests::example_21"},ignore
 /// ```
 pub fn into<I, O1, O2, E1, E2, F>(parser: F) -> impl Parser<I, Output = O2, Error = E2>
 where
@@ -874,18 +612,7 @@ where
 ///
 /// On [`Err::Error`], iteration will stop. To instead chain an error up, see [`cut`].
 ///
-/// ```rust
-/// use nom::{combinator::iterator, IResult, bytes::complete::tag, character::complete::alpha1, sequence::terminated};
-/// use std::collections::HashMap;
-///
-/// let data = "abc|defg|hijkl|mnopqr|123";
-/// let mut it = iterator(data, terminated(alpha1, tag("|")));
-///
-/// let parsed = it.by_ref().map(|v| (v, v.len())).collect::<HashMap<_,_>>();
-/// let res: IResult<_,_> = it.finish();
-///
-/// assert_eq!(parsed, [("abc", 3usize), ("defg", 4), ("hijkl", 5), ("mnopqr", 6)].iter().cloned().collect());
-/// assert_eq!(res, Ok(("123", ())));
+/// ```rust,{source="doctests::example_22"},ignore
 /// ```
 pub fn iterator<Input, Error, F>(input: Input, f: F) -> ParserIterator<Input, Error, F>
 where
@@ -965,21 +692,7 @@ enum State<E> {
 /// It can be used for example as the last alternative in `alt` to
 /// specify the default case.
 ///
-/// ```rust
-/// # use nom::{Err,error::ErrorKind, IResult, Parser};
-/// use nom::branch::alt;
-/// use nom::combinator::{success, value};
-/// use nom::character::complete::char;
-/// # fn main() {
-///
-/// let mut parser = success::<_,_,(_,ErrorKind)>(10);
-/// assert_eq!(parser.parse("xyz"), Ok(("xyz", 10)));
-///
-/// let mut sign = alt((value(-1, char('-')), value(1, char('+')), success::<_,_,(_,ErrorKind)>(1)));
-/// assert_eq!(sign.parse("+10"), Ok(("10", 1)));
-/// assert_eq!(sign.parse("-10"), Ok(("10", -1)));
-/// assert_eq!(sign.parse("10"), Ok(("10", 1)));
-/// # }
+/// ```rust,{source="doctests::example_23"},ignore
 /// ```
 pub fn success<I, O: Clone, E: ParseError<I>>(val: O) -> impl Parser<I, Output = O, Error = E> {
   Success {
@@ -1009,12 +722,7 @@ where
 
 /// A parser which always fails.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, IResult, Parser};
-/// use nom::combinator::fail;
-///
-/// let s = "string";
-/// assert_eq!(fail::<_, &str, _>().parse(s), Err(Err::Error((s, ErrorKind::Fail))));
+/// ```rust,{source="doctests::example_24"},ignore
 /// ```
 pub fn fail<I, O, E: ParseError<I>>() -> impl Parser<I, Output = O, Error = E> {
   Fail {
@@ -1040,5 +748,406 @@ where
     Err(Err::Error(OM::Error::bind(|| {
       E::from_error_kind(input, ErrorKind::Fail)
     })))
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::branch::alt;
+  use nom::character::complete::{digit1, one_of};
+  use nom::combinator::{eof, rest};
+  use nom::sequence::preceded;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult, Parser,
+  };
+
+  #[test]
+  fn example_1() {
+    use nom::combinator::rest;
+    assert_eq!(rest::<_, (_, ErrorKind)>("abc"), Ok(("", "abc")));
+    assert_eq!(rest::<_, (_, ErrorKind)>(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::combinator::rest_len;
+    assert_eq!(rest_len::<_, (_, ErrorKind)>("abc"), Ok(("abc", 3)));
+    assert_eq!(rest_len::<_, (_, ErrorKind)>(""), Ok(("", 0)));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::character::complete::digit1;
+    use nom::combinator::map;
+    use nom::{error::ErrorKind, Err, IResult, Parser};
+
+    let mut parser = map(digit1, |s: &str| s.len());
+
+    // the parser will count how many characters were returned by digit1
+    assert_eq!(parser.parse("123456"), Ok(("", 6)));
+
+    // this will fail if digit1 fails
+    assert_eq!(
+      parser.parse("abc"),
+      Err(Err::Error(("abc", ErrorKind::Digit)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::character::complete::digit1;
+    use nom::combinator::map_res;
+
+    let mut parse = map_res(digit1, |s: &str| s.parse::<u8>());
+
+    // the parser will convert the result of digit1 to a number
+    assert_eq!(parse.parse("123"), Ok(("", 123)));
+
+    // this will fail if digit1 fails
+    assert_eq!(
+      parse.parse("abc"),
+      Err(Err::Error(("abc", ErrorKind::Digit)))
+    );
+
+    // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
+    assert_eq!(
+      parse.parse("123456"),
+      Err(Err::Error(("123456", ErrorKind::MapRes)))
+    );
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::character::complete::digit1;
+    use nom::combinator::map_opt;
+
+    let mut parse = map_opt(digit1, |s: &str| s.parse::<u8>().ok());
+
+    // the parser will convert the result of digit1 to a number
+    assert_eq!(parse.parse("123"), Ok(("", 123)));
+
+    // this will fail if digit1 fails
+    assert_eq!(
+      parse.parse("abc"),
+      Err(Err::Error(("abc", ErrorKind::Digit)))
+    );
+
+    // this will fail if the mapped function fails (a `u8` is too small to hold `123456`)
+    assert_eq!(
+      parse.parse("123456"),
+      Err(Err::Error(("123456", ErrorKind::MapOpt)))
+    );
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::bytes::complete::take;
+    use nom::character::complete::digit1;
+    use nom::combinator::map_parser;
+
+    let mut parse = map_parser(take(5u8), digit1);
+
+    assert_eq!(parse.parse("12345"), Ok(("", "12345")));
+    assert_eq!(parse.parse("123ab"), Ok(("", "123")));
+    assert_eq!(parse.parse("123"), Err(Err::Error(("123", ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::bytes::complete::take;
+    use nom::combinator::flat_map;
+    use nom::number::complete::u8;
+
+    let mut parse = flat_map(u8, take);
+
+    assert_eq!(parse.parse(&[2, 0, 1, 2][..]), Ok((&[2][..], &[0, 1][..])));
+    assert_eq!(
+      parse.parse(&[4, 0, 1, 2][..]),
+      Err(Err::Error((&[0, 1, 2][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::opt;
+
+    fn parser(i: &str) -> IResult<&str, Option<&str>> {
+      opt(alpha1).parse(i)
+    }
+
+    assert_eq!(parser("abcd;"), Ok((";", Some("abcd"))));
+    assert_eq!(parser("123;"), Ok(("123;", None)));
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::cond;
+
+    fn parser(b: bool, i: &str) -> IResult<&str, Option<&str>> {
+      cond(b, alpha1).parse(i)
+    }
+
+    assert_eq!(parser(true, "abcd;"), Ok((";", Some("abcd"))));
+    assert_eq!(parser(false, "abcd;"), Ok(("abcd;", None)));
+    assert_eq!(
+      parser(true, "123;"),
+      Err(Err::Error(Error::new("123;", ErrorKind::Alpha)))
+    );
+    assert_eq!(parser(false, "123;"), Ok(("123;", None)));
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::peek;
+
+    let mut parser = peek(alpha1);
+
+    assert_eq!(parser.parse("abcd;"), Ok(("abcd;", "abcd")));
+    assert_eq!(
+      parser.parse("123;"),
+      Err(Err::Error(("123;", ErrorKind::Alpha)))
+    );
+  }
+
+  #[test]
+  fn example_11() {
+    let parser = eof;
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Eof))));
+    assert_eq!(parser(""), Ok(("", "")));
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::bytes::streaming::take;
+    use nom::combinator::complete;
+
+    let mut parser = complete(take(5u8));
+
+    assert_eq!(parser.parse("abcdefg"), Ok(("fg", "abcde")));
+    assert_eq!(
+      parser.parse("abcd"),
+      Err(Err::Error(("abcd", ErrorKind::Complete)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::all_consuming;
+
+    let mut parser = all_consuming(alpha1);
+
+    assert_eq!(parser.parse("abcd"), Ok(("", "abcd")));
+    assert_eq!(
+      parser.parse("abcd;"),
+      Err(Err::Error((";", ErrorKind::Eof)))
+    );
+    assert_eq!(
+      parser.parse("123abcd;"),
+      Err(Err::Error(("123abcd;", ErrorKind::Alpha)))
+    );
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::verify;
+
+    let mut parser = verify(alpha1, |s: &str| s.len() == 4);
+
+    assert_eq!(parser.parse("abcd"), Ok(("", "abcd")));
+    assert_eq!(
+      parser.parse("abcde"),
+      Err(Err::Error(("abcde", ErrorKind::Verify)))
+    );
+    assert_eq!(
+      parser.parse("123abcd;"),
+      Err(Err::Error(("123abcd;", ErrorKind::Alpha)))
+    );
+  }
+
+  #[test]
+  fn example_15() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::value;
+
+    let mut parser = value(1234, alpha1);
+
+    assert_eq!(parser.parse("abcd"), Ok(("", 1234)));
+    assert_eq!(
+      parser.parse("123abcd;"),
+      Err(Err::Error(("123abcd;", ErrorKind::Alpha)))
+    );
+  }
+
+  #[test]
+  fn example_16() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::not;
+
+    let mut parser = not(alpha1);
+
+    assert_eq!(parser.parse("123"), Ok(("123", ())));
+    assert_eq!(
+      parser.parse("abcd"),
+      Err(Err::Error(("abcd", ErrorKind::Not)))
+    );
+  }
+
+  #[test]
+  fn example_17() {
+    use nom::character::complete::{alpha1, char};
+    use nom::combinator::recognize;
+    use nom::sequence::separated_pair;
+
+    let mut parser = recognize(separated_pair(alpha1, char(','), alpha1));
+
+    assert_eq!(parser.parse("abcd,efgh"), Ok(("", "abcd,efgh")));
+    assert_eq!(
+      parser.parse("abcd;"),
+      Err(Err::Error((";", ErrorKind::Char)))
+    );
+  }
+
+  #[test]
+  fn example_18() {
+    use nom::bytes::complete::tag;
+    use nom::character::complete::{alpha1, char};
+    use nom::combinator::{consumed, map, recognize, value};
+    use nom::sequence::separated_pair;
+
+    fn inner_parser(input: &str) -> IResult<&str, bool> {
+      value(true, tag("1234")).parse(input)
+    }
+
+    let mut consumed_parser = consumed(value(true, separated_pair(alpha1, char(','), alpha1)));
+
+    assert_eq!(
+      consumed_parser.parse("abcd,efgh1"),
+      Ok(("1", ("abcd,efgh", true)))
+    );
+    assert_eq!(
+      consumed_parser.parse("abcd;"),
+      Err(Err::Error((";", ErrorKind::Char)))
+    );
+
+    // the first output (representing the consumed input)
+    // should be the same as that of the `recognize` parser.
+    let mut recognize_parser = recognize(inner_parser);
+    let mut consumed_parser = map(consumed(inner_parser), |(consumed, output)| consumed);
+
+    assert_eq!(
+      recognize_parser.parse("1234"),
+      consumed_parser.parse("1234")
+    );
+    assert_eq!(
+      recognize_parser.parse("abcd"),
+      consumed_parser.parse("abcd")
+    );
+  }
+
+  #[test]
+  fn example_19() {
+    fn parser(input: &str) -> IResult<&str, &str> {
+      alt((preceded(one_of("+-"), digit1), rest)).parse(input)
+    }
+
+    assert_eq!(parser("+10 ab"), Ok((" ab", "10")));
+    assert_eq!(parser("ab"), Ok(("", "ab")));
+    assert_eq!(parser("+"), Ok(("", "+")));
+  }
+
+  #[test]
+  fn example_20() {
+    use nom::combinator::cut;
+
+    fn parser(input: &str) -> IResult<&str, &str> {
+      alt((preceded(one_of("+-"), cut(digit1)), rest)).parse(input)
+    }
+
+    assert_eq!(parser("+10 ab"), Ok((" ab", "10")));
+    assert_eq!(parser("ab"), Ok(("", "ab")));
+    assert_eq!(
+      parser("+"),
+      Err(Err::Failure(Error {
+        input: "",
+        code: ErrorKind::Digit
+      }))
+    );
+  }
+
+  #[test]
+  fn example_21() {
+    use nom::character::complete::alpha1;
+    use nom::combinator::into;
+
+    fn parser1(i: &str) -> IResult<&str, &str> {
+      alpha1(i)
+    }
+
+    let mut parser2 = into(parser1);
+
+    // the parser converts the &str output of the child parser into a Vec<u8>
+    let bytes: IResult<&str, Vec<u8>> = parser2.parse("abcd");
+    assert_eq!(bytes, Ok(("", vec![97, 98, 99, 100])));
+  }
+
+  #[test]
+  fn example_22() {
+    use nom::{
+      bytes::complete::tag, character::complete::alpha1, combinator::iterator,
+      sequence::terminated, IResult,
+    };
+    use std::collections::HashMap;
+
+    let data = "abc|defg|hijkl|mnopqr|123";
+    let mut it = iterator(data, terminated(alpha1, tag("|")));
+
+    let parsed = it.by_ref().map(|v| (v, v.len())).collect::<HashMap<_, _>>();
+    let res: IResult<_, _> = it.finish();
+
+    assert_eq!(
+      parsed,
+      [("abc", 3usize), ("defg", 4), ("hijkl", 5), ("mnopqr", 6)]
+        .iter()
+        .cloned()
+        .collect()
+    );
+    assert_eq!(res, Ok(("123", ())));
+  }
+
+  #[test]
+  fn example_23() {
+    use nom::branch::alt;
+    use nom::character::complete::char;
+    use nom::combinator::{success, value};
+
+    let mut parser = success::<_, _, (_, ErrorKind)>(10);
+    assert_eq!(parser.parse("xyz"), Ok(("xyz", 10)));
+
+    let mut sign = alt((
+      value(-1, char('-')),
+      value(1, char('+')),
+      success::<_, _, (_, ErrorKind)>(1),
+    ));
+    assert_eq!(sign.parse("+10"), Ok(("10", 1)));
+    assert_eq!(sign.parse("-10"), Ok(("10", -1)));
+    assert_eq!(sign.parse("10"), Ok(("10", 1)));
+  }
+
+  #[test]
+  fn example_24() {
+    use nom::combinator::fail;
+
+    let s = "string";
+    assert_eq!(
+      fail::<_, &str, _>().parse(s),
+      Err(Err::Error((s, ErrorKind::Fail)))
+    );
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -473,19 +473,7 @@ macro_rules! error_node_position(
 ///
 /// It also displays the input in hexdump format
 ///
-/// ```rust
-/// use nom::{IResult, error::dbg_dmp, bytes::complete::tag};
-///
-/// fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
-///   dbg_dmp(tag("abcd"), "tag")(i)
-/// }
-///
-///   let a = &b"efghijkl"[..];
-///
-/// // Will print the following message:
-/// // Error(Position(0, [101, 102, 103, 104, 105, 106, 107, 108])) at l.5 by ' tag ! ( "abcd" ) '
-/// // 00000000        65 66 67 68 69 6a 6b 6c         efghijkl
-/// f(a);
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[cfg(feature = "std")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "std")))]
@@ -800,3 +788,24 @@ pub fn print_offsets(input: &[u8], from: usize, offsets: &[(ErrorKind, usize, us
   String::from_utf8_lossy(&v[..]).into_owned()
 }
 */
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+
+  #[test]
+  fn example_1() {
+    use nom::{bytes::complete::tag, error::dbg_dmp, IResult};
+
+    fn f(i: &[u8]) -> IResult<&[u8], &[u8]> {
+      dbg_dmp(tag("abcd"), "tag")(i)
+    }
+
+    let a = &b"efghijkl"[..];
+
+    // Will print the following message:
+    // Error(Position(0, [101, 102, 103, 104, 105, 106, 107, 108])) at l.5 by ' tag ! ( "abcd" ) '
+    // 00000000        65 66 67 68 69 6a 6b 6c         efghijkl
+    f(a);
+  }
+}

--- a/src/multi/mod.rs
+++ b/src/multi/mod.rs
@@ -44,19 +44,7 @@ const MAX_INITIAL_CAPACITY_BYTES: usize = 65536;
 /// *Note*: if the parser passed in accepts empty inputs (like `alpha0` or `digit0`), `many0` will
 /// return an error, to prevent going into an infinite loop
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::many0;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many0(tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -131,19 +119,7 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::many1;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many1(tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -231,20 +207,7 @@ where
 ///
 /// `f` keeps going so long as `g` produces [`Err::Error`]. To instead chain an error up, see [`cut`][crate::combinator::cut].
 ///
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::many_till;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
-///   many_till(tag("abc"), tag("end")).parse(s)
-/// };
-///
-/// assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
-/// assert_eq!(parser("abc123end"), Err(Err::Error(Error::new("123end", ErrorKind::Tag))));
-/// assert_eq!(parser("123123end"), Err(Err::Error(Error::new("123123end", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -338,20 +301,7 @@ where
 /// * `sep` Parses the separator between list elements.
 /// * `f` Parses the elements of the list.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::separated_list0;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated_list0(tag("|"), tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
-/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
-/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -459,20 +409,7 @@ where
 /// # Arguments
 /// * `sep` Parses the separator between list elements.
 /// * `f` Parses the elements of the list.
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::separated_list1;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   separated_list1(tag("|"), tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
-/// assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
-/// assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("def|abc"), Err(Err::Error(Error::new("def|abc", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -575,20 +512,7 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::many_m_n;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many_m_n(0, 2, tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -685,19 +609,7 @@ where
 /// *Note*: if the parser passed in accepts empty inputs (like `alpha0` or `digit0`), `many0` will
 /// return an error, to prevent going into an infinite loop
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::many0_count;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, usize> {
-///   many0_count(tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", 2)));
-/// assert_eq!(parser("abc123"), Ok(("123", 1)));
-/// assert_eq!(parser("123123"), Ok(("123123", 0)));
-/// assert_eq!(parser(""), Ok(("", 0)));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 pub fn many0_count<I, E, F>(parser: F) -> impl Parser<I, Output = usize, Error = E>
 where
@@ -766,19 +678,7 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::many1_count;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, usize> {
-///   many1_count(tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", 2)));
-/// assert_eq!(parser("abc123"), Ok(("123", 1)));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1Count))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1Count))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 pub fn many1_count<I, E, F>(parser: F) -> impl Parser<I, Output = usize, Error = E>
 where
@@ -854,20 +754,7 @@ where
 /// # Arguments
 /// * `f` The parser to apply.
 /// * `count` How often to apply the parser.
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::count;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   count(tag("abc"), 2).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -938,22 +825,7 @@ where
 /// # Arguments
 /// * `f` The parser to apply.
 /// * `buf` The slice to fill
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::fill;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, [&str; 2]> {
-///   let mut buf = ["", ""];
-///   let (rest, ()) = fill(tag("abc"), &mut buf).parse(s)?;
-///   Ok((rest, buf))
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", ["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Err(Err::Error(Error::new("123", ErrorKind::Tag))));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Tag))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 pub fn fill<'a, I, E, F>(
   parser: F,
@@ -1020,26 +892,7 @@ where
 /// *Note*: if the parser passed in accepts empty inputs (like `alpha0` or `digit0`), `many0` will
 /// return an error, to prevent going into an infinite loop
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::fold_many0;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   fold_many0(
-///     tag("abc"),
-///     Vec::new,
-///     |mut acc: Vec<_>, item| {
-///       acc.push(item);
-///       acc
-///     }
-///   ).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 pub fn fold_many0<I, E, F, G, H, R>(
   parser: F,
@@ -1124,26 +977,7 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::multi::fold_many1;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   fold_many1(
-///     tag("abc"),
-///     Vec::new,
-///     |mut acc: Vec<_>, item| {
-///       acc.push(item);
-///       acc
-///     }
-///   ).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Err(Err::Error(Error::new("123123", ErrorKind::Many1))));
-/// assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Many1))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 pub fn fold_many1<I, E, F, G, H, R>(
   parser: F,
@@ -1241,29 +1075,7 @@ where
 /// (like `alpha0` or `digit0`), `many1` will return an error,
 /// to prevent going into an infinite loop.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::fold_many_m_n;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   fold_many_m_n(
-///     0,
-///     2,
-///     tag("abc"),
-///     Vec::new,
-///     |mut acc: Vec<_>, item| {
-///       acc.push(item);
-///       acc
-///     }
-///   ).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 pub fn fold_many_m_n<I, E, F, G, H, R>(
   min: usize,
@@ -1357,18 +1169,7 @@ where
 /// `length_data` will return an error.
 /// # Arguments
 /// * `f` The parser to apply.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::number::complete::be_u16;
-/// use nom::multi::length_data;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   length_data(be_u16).parse(s)
-/// }
-///
-/// assert_eq!(parser(b"\x00\x03abcefg"), Ok((&b"efg"[..], &b"abc"[..])));
-/// assert_eq!(parser(b"\x00\x03a"), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 pub fn length_data<I, E, F>(f: F) -> impl Parser<I, Output = I, Error = E>
 where
@@ -1388,19 +1189,7 @@ where
 /// # Arguments
 /// * `f` The parser to apply.
 /// * `g` The parser to apply on the subslice.
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::number::complete::be_u16;
-/// use nom::multi::length_value;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
-///   length_value(be_u16, tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser(b"\x00\x03abcefg"), Ok((&b"efg"[..], &b"abc"[..])));
-/// assert_eq!(parser(b"\x00\x03123123"), Err(Err::Error(Error::new(&b"123"[..], ErrorKind::Tag))));
-/// assert_eq!(parser(b"\x00\x03a"), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 pub fn length_value<I, E, F, G>(
   f: F,
@@ -1476,22 +1265,7 @@ where
 /// # Arguments
 /// * `f` The parser to apply to obtain the count.
 /// * `g` The parser to apply repeatedly.
-/// ```rust
-/// # use nom::{Err, error::{Error, ErrorKind}, Needed, IResult, Parser};
-/// use nom::number::complete::u8;
-/// use nom::multi::length_count;
-/// use nom::bytes::complete::tag;
-/// use nom::combinator::map;
-///
-/// fn parser(s: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
-///   length_count(map(u8, |i| {
-///      println!("got number: {}", i);
-///      i
-///   }), tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser(&b"\x02abcabcabc"[..]), Ok(((&b"abc"[..], vec![&b"abc"[..], &b"abc"[..]]))));
-/// assert_eq!(parser(b"\x03123123123"), Err(Err::Error(Error::new(&b"123123123"[..], ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_16"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 pub fn length_count<I, E, F, G>(
@@ -1587,78 +1361,19 @@ where
 ///   * An empty range is invalid.
 /// * `parse` The parser to apply.
 ///
-/// ```rust
-/// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::many;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   many(0..=2, tag("abc")).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 ///
 /// This is not limited to `Vec`, other collections like `HashMap`
 /// can be used:
 ///
-/// ```rust
-/// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::many;
-/// use nom::bytes::complete::{tag, take_while};
-/// use nom::sequence::{separated_pair, terminated};
-/// use nom::AsChar;
-///
-/// use std::collections::HashMap;
-///
-/// fn key_value(s: &str) -> IResult<&str, HashMap<&str, &str>> {
-///   many(0.., terminated(
-///     separated_pair(
-///       take_while(AsChar::is_alpha),
-///       tag("="),
-///       take_while(AsChar::is_alpha)
-///     ),
-///     tag(";")
-///   )).parse(s)
-/// }
-///
-/// assert_eq!(
-///   key_value("a=b;c=d;"),
-///   Ok(("", HashMap::from([("a", "b"), ("c", "d")])))
-/// );
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 ///
 /// If more control is needed on the default value, [fold] can
 /// be used instead:
 ///
-/// ```rust
-/// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::fold;
-/// use nom::bytes::complete::tag;
-///
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   fold(
-///     0..=4,
-///     tag("abc"),
-///     // preallocates a vector of the max size
-///     || Vec::with_capacity(4),
-///     |mut acc: Vec<_>, item| {
-///       acc.push(item);
-///       acc
-///     }
-///   ).parse(s)
-/// }
-///
-///
-/// assert_eq!(parser("abcabcabcabc"), Ok(("", vec!["abc", "abc", "abc", "abc"])));
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 #[cfg(feature = "alloc")]
 #[cfg_attr(feature = "docsrs", doc(cfg(feature = "alloc")))]
@@ -1760,29 +1475,7 @@ where
 /// * `init` A function returning the initial value.
 /// * `fold` The function that combines a result of `f` with
 ///       the current accumulator.
-/// ```rust
-/// # #[macro_use] extern crate nom;
-/// # use nom::{Err, error::ErrorKind, Needed, IResult, Parser};
-/// use nom::multi::fold;
-/// use nom::bytes::complete::tag;
-///
-/// fn parser(s: &str) -> IResult<&str, Vec<&str>> {
-///   fold(
-///     0..=2,
-///     tag("abc"),
-///     Vec::new,
-///     |mut acc: Vec<_>, item| {
-///       acc.push(item);
-///       acc
-///     }
-///   ).parse(s)
-/// }
-///
-/// assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
-/// assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
-/// assert_eq!(parser("123123"), Ok(("123123", vec![])));
-/// assert_eq!(parser(""), Ok(("", vec![])));
-/// assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 pub fn fold<I, E, F, G, H, J, R>(
   range: J,
@@ -1866,5 +1559,416 @@ where
     }
 
     Ok((input, acc))
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::{
+    error::{Error, ErrorKind},
+    Err, IResult, Needed, Parser,
+  };
+
+  #[test]
+  fn example_1() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many0;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      many0(tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(parser("123123"), Ok(("123123", vec![])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many1;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      many1(tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(
+      parser("123123"),
+      Err(Err::Error(Error::new("123123", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many_till;
+
+    fn parser(s: &str) -> IResult<&str, (Vec<&str>, &str)> {
+      many_till(tag("abc"), tag("end")).parse(s)
+    };
+
+    assert_eq!(parser("abcabcend"), Ok(("", (vec!["abc", "abc"], "end"))));
+    assert_eq!(
+      parser("abc123end"),
+      Err(Err::Error(Error::new("123end", ErrorKind::Tag)))
+    );
+    assert_eq!(
+      parser("123123end"),
+      Err(Err::Error(Error::new("123123end", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+    assert_eq!(parser("abcendefg"), Ok(("efg", (vec!["abc"], "end"))));
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::bytes::complete::tag;
+    use nom::multi::separated_list0;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      separated_list0(tag("|"), tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
+    assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
+    assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+    assert_eq!(parser("def|abc"), Ok(("def|abc", vec![])));
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::bytes::complete::tag;
+    use nom::multi::separated_list1;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      separated_list1(tag("|"), tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abc|abc|abc"), Ok(("", vec!["abc", "abc", "abc"])));
+    assert_eq!(parser("abc123abc"), Ok(("123abc", vec!["abc"])));
+    assert_eq!(parser("abc|def"), Ok(("|def", vec!["abc"])));
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+    assert_eq!(
+      parser("def|abc"),
+      Err(Err::Error(Error::new("def|abc", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many_m_n;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      many_m_n(0, 2, tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(parser("123123"), Ok(("123123", vec![])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+    assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many0_count;
+
+    fn parser(s: &str) -> IResult<&str, usize> {
+      many0_count(tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", 2)));
+    assert_eq!(parser("abc123"), Ok(("123", 1)));
+    assert_eq!(parser("123123"), Ok(("123123", 0)));
+    assert_eq!(parser(""), Ok(("", 0)));
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many1_count;
+
+    fn parser(s: &str) -> IResult<&str, usize> {
+      many1_count(tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", 2)));
+    assert_eq!(parser("abc123"), Ok(("123", 1)));
+    assert_eq!(
+      parser("123123"),
+      Err(Err::Error(Error::new("123123", ErrorKind::Many1Count)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Many1Count)))
+    );
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::bytes::complete::tag;
+    use nom::multi::count;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      count(tag("abc"), 2).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(
+      parser("abc123"),
+      Err(Err::Error(Error::new("123", ErrorKind::Tag)))
+    );
+    assert_eq!(
+      parser("123123"),
+      Err(Err::Error(Error::new("123123", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+    assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::bytes::complete::tag;
+    use nom::multi::fill;
+
+    fn parser(s: &str) -> IResult<&str, [&str; 2]> {
+      let mut buf = ["", ""];
+      let (rest, ()) = fill(tag("abc"), &mut buf).parse(s)?;
+      Ok((rest, buf))
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", ["abc", "abc"])));
+    assert_eq!(
+      parser("abc123"),
+      Err(Err::Error(Error::new("123", ErrorKind::Tag)))
+    );
+    assert_eq!(
+      parser("123123"),
+      Err(Err::Error(Error::new("123123", ErrorKind::Tag)))
+    );
+    assert_eq!(parser(""), Err(Err::Error(Error::new("", ErrorKind::Tag))));
+    assert_eq!(parser("abcabcabc"), Ok(("abc", ["abc", "abc"])));
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::bytes::complete::tag;
+    use nom::multi::fold_many0;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      fold_many0(tag("abc"), Vec::new, |mut acc: Vec<_>, item| {
+        acc.push(item);
+        acc
+      })
+      .parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(parser("123123"), Ok(("123123", vec![])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::bytes::complete::tag;
+    use nom::multi::fold_many1;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      fold_many1(tag("abc"), Vec::new, |mut acc: Vec<_>, item| {
+        acc.push(item);
+        acc
+      })
+      .parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(
+      parser("123123"),
+      Err(Err::Error(Error::new("123123", ErrorKind::Many1)))
+    );
+    assert_eq!(
+      parser(""),
+      Err(Err::Error(Error::new("", ErrorKind::Many1)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::bytes::complete::tag;
+    use nom::multi::fold_many_m_n;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      fold_many_m_n(0, 2, tag("abc"), Vec::new, |mut acc: Vec<_>, item| {
+        acc.push(item);
+        acc
+      })
+      .parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(parser("123123"), Ok(("123123", vec![])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+    assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::multi::length_data;
+    use nom::number::complete::be_u16;
+
+    fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      length_data(be_u16).parse(s)
+    }
+
+    assert_eq!(parser(b"\x00\x03abcefg"), Ok((&b"efg"[..], &b"abc"[..])));
+    assert_eq!(parser(b"\x00\x03a"), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_15() {
+    use nom::bytes::complete::tag;
+    use nom::multi::length_value;
+    use nom::number::complete::be_u16;
+
+    fn parser(s: &[u8]) -> IResult<&[u8], &[u8]> {
+      length_value(be_u16, tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser(b"\x00\x03abcefg"), Ok((&b"efg"[..], &b"abc"[..])));
+    assert_eq!(
+      parser(b"\x00\x03123123"),
+      Err(Err::Error(Error::new(&b"123"[..], ErrorKind::Tag)))
+    );
+    assert_eq!(parser(b"\x00\x03a"), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_16() {
+    use nom::bytes::complete::tag;
+    use nom::combinator::map;
+    use nom::multi::length_count;
+    use nom::number::complete::u8;
+
+    fn parser(s: &[u8]) -> IResult<&[u8], Vec<&[u8]>> {
+      length_count(
+        map(u8, |i| {
+          println!("got number: {}", i);
+          i
+        }),
+        tag("abc"),
+      )
+      .parse(s)
+    }
+
+    assert_eq!(
+      parser(&b"\x02abcabcabc"[..]),
+      Ok((&b"abc"[..], vec![&b"abc"[..], &b"abc"[..]]))
+    );
+    assert_eq!(
+      parser(b"\x03123123123"),
+      Err(Err::Error(Error::new(&b"123123123"[..], ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_17() {
+    use nom::bytes::complete::tag;
+    use nom::multi::many;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      many(0..=2, tag("abc")).parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(parser("123123"), Ok(("123123", vec![])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+    assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
+  }
+
+  #[test]
+  fn example_18() {
+    use nom::bytes::complete::{tag, take_while};
+    use nom::multi::many;
+    use nom::sequence::{separated_pair, terminated};
+    use nom::AsChar;
+
+    use std::collections::HashMap;
+
+    fn key_value(s: &str) -> IResult<&str, HashMap<&str, &str>> {
+      many(
+        0..,
+        terminated(
+          separated_pair(
+            take_while(AsChar::is_alpha),
+            tag("="),
+            take_while(AsChar::is_alpha),
+          ),
+          tag(";"),
+        ),
+      )
+      .parse(s)
+    }
+
+    assert_eq!(
+      key_value("a=b;c=d;"),
+      Ok(("", HashMap::from([("a", "b"), ("c", "d")])))
+    );
+  }
+
+  #[test]
+  fn example_19() {
+    use nom::bytes::complete::tag;
+    use nom::multi::fold;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      fold(
+        0..=4,
+        tag("abc"),
+        // preallocates a vector of the max size
+        || Vec::with_capacity(4),
+        |mut acc: Vec<_>, item| {
+          acc.push(item);
+          acc
+        },
+      )
+      .parse(s)
+    }
+
+    assert_eq!(
+      parser("abcabcabcabc"),
+      Ok(("", vec!["abc", "abc", "abc", "abc"]))
+    );
+  }
+
+  #[test]
+  fn example_20() {
+    use nom::bytes::complete::tag;
+    use nom::multi::fold;
+
+    fn parser(s: &str) -> IResult<&str, Vec<&str>> {
+      fold(0..=2, tag("abc"), Vec::new, |mut acc: Vec<_>, item| {
+        acc.push(item);
+        acc
+      })
+      .parse(s)
+    }
+
+    assert_eq!(parser("abcabc"), Ok(("", vec!["abc", "abc"])));
+    assert_eq!(parser("abc123"), Ok(("123", vec!["abc"])));
+    assert_eq!(parser("123123"), Ok(("123123", vec![])));
+    assert_eq!(parser(""), Ok(("", vec![])));
+    assert_eq!(parser("abcabcabc"), Ok(("abc", vec!["abc", "abc"])));
   }
 }

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -14,17 +14,7 @@ use crate::traits::{AsBytes, AsChar, Compare, Input, Offset};
 /// Recognizes an unsigned 1 byte integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_u8;
-///
-/// let parser = |s| {
-///   be_u8(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[inline]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -37,17 +27,7 @@ where
 /// Recognizes a big endian unsigned 2 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_u16;
-///
-/// let parser = |s| {
-///   be_u16(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 #[inline]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
@@ -60,17 +40,7 @@ where
 /// Recognizes a big endian unsigned 3 byte integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_u24;
-///
-/// let parser = |s| {
-///   be_u24(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 #[inline]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -83,17 +53,7 @@ where
 /// Recognizes a big endian unsigned 4 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_u32;
-///
-/// let parser = |s| {
-///   be_u32(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 #[inline]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -106,17 +66,7 @@ where
 /// Recognizes a big endian unsigned 8 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_u64;
-///
-/// let parser = |s| {
-///   be_u64(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 #[inline]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
@@ -129,17 +79,7 @@ where
 /// Recognizes a big endian unsigned 16 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_u128;
-///
-/// let parser = |s| {
-///   be_u128(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 #[inline]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
@@ -161,17 +101,7 @@ where
 /// Recognizes a signed 1 byte integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_i8;
-///
-/// let parser = |s| {
-///   be_i8(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 #[inline]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -184,17 +114,7 @@ where
 /// Recognizes a big endian signed 2 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_i16;
-///
-/// let parser = |s| {
-///   be_i16(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 #[inline]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
@@ -207,17 +127,7 @@ where
 /// Recognizes a big endian signed 3 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_i24;
-///
-/// let parser = |s| {
-///   be_i24(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[inline]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -239,17 +149,7 @@ where
 /// Recognizes a big endian signed 4 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_i32;
-///
-/// let parser = |s| {
-///   be_i32(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 #[inline]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -262,17 +162,7 @@ where
 /// Recognizes a big endian signed 8 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_i64;
-///
-/// let parser = |s| {
-///   be_i64(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 #[inline]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
@@ -285,17 +175,7 @@ where
 /// Recognizes a big endian signed 16 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_i128;
-///
-/// let parser = |s| {
-///   be_i128(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 #[inline]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
@@ -308,17 +188,7 @@ where
 /// Recognizes an unsigned 1 byte integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_u8;
-///
-/// let parser = |s| {
-///   le_u8(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 #[inline]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -331,17 +201,7 @@ where
 /// Recognizes a little endian unsigned 2 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_u16;
-///
-/// let parser = |s| {
-///   le_u16(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 #[inline]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
@@ -354,17 +214,7 @@ where
 /// Recognizes a little endian unsigned 3 byte integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_u24;
-///
-/// let parser = |s| {
-///   le_u24(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 #[inline]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -377,17 +227,7 @@ where
 /// Recognizes a little endian unsigned 4 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_u32;
-///
-/// let parser = |s| {
-///   le_u32(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_16"},ignore
 /// ```
 #[inline]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -400,17 +240,7 @@ where
 /// Recognizes a little endian unsigned 8 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_u64;
-///
-/// let parser = |s| {
-///   le_u64(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 #[inline]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
@@ -423,17 +253,7 @@ where
 /// Recognizes a little endian unsigned 16 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_u128;
-///
-/// let parser = |s| {
-///   le_u128(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 #[inline]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
@@ -455,17 +275,7 @@ where
 /// Recognizes a signed 1 byte integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_i8;
-///
-/// let parser = |s| {
-///   le_i8(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 #[inline]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -478,17 +288,7 @@ where
 /// Recognizes a little endian signed 2 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_i16;
-///
-/// let parser = |s| {
-///   le_i16(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 #[inline]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
@@ -501,17 +301,7 @@ where
 /// Recognizes a little endian signed 3 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_i24;
-///
-/// let parser = |s| {
-///   le_i24(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_21"},ignore
 /// ```
 #[inline]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -533,17 +323,7 @@ where
 /// Recognizes a little endian signed 4 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_i32;
-///
-/// let parser = |s| {
-///   le_i32(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_22"},ignore
 /// ```
 #[inline]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -556,17 +336,7 @@ where
 /// Recognizes a little endian signed 8 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_i64;
-///
-/// let parser = |s| {
-///   le_i64(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_23"},ignore
 /// ```
 #[inline]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
@@ -579,17 +349,7 @@ where
 /// Recognizes a little endian signed 16 bytes integer.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_i128;
-///
-/// let parser = |s| {
-///   le_i128(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_24"},ignore
 /// ```
 #[inline]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
@@ -603,17 +363,7 @@ where
 ///
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::u8;
-///
-/// let parser = |s| {
-///   u8(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_25"},ignore
 /// ```
 #[inline]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -629,24 +379,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u16 integer.
 /// *complete version*: returns an error if there is not enough input data
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::u16;
-///
-/// let be_u16 = |s| {
-///   u16(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_u16 = |s| {
-///   u16(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_26"},ignore
 /// ```
 #[inline]
 pub fn u16<I, E: ParseError<I>>(
@@ -663,24 +396,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u24 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::u24;
-///
-/// let be_u24 = |s| {
-///   u24(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_u24 = |s| {
-///   u24(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_27"},ignore
 /// ```
 #[inline]
 pub fn u24<I, E: ParseError<I>>(
@@ -697,24 +413,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u32 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::u32;
-///
-/// let be_u32 = |s| {
-///   u32(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_u32 = |s| {
-///   u32(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_28"},ignore
 /// ```
 #[inline]
 pub fn u32<I, E: ParseError<I>>(
@@ -731,24 +430,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u64 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::u64;
-///
-/// let be_u64 = |s| {
-///   u64(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_u64 = |s| {
-///   u64(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_29"},ignore
 /// ```
 #[inline]
 pub fn u64<I, E: ParseError<I>>(
@@ -765,24 +447,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u128 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::u128;
-///
-/// let be_u128 = |s| {
-///   u128(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_u128 = |s| {
-///   u128(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_30"},ignore
 /// ```
 #[inline]
 pub fn u128<I, E: ParseError<I>>(
@@ -798,17 +463,7 @@ where
 ///
 /// Note that endianness does not apply to 1 byte numbers.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::i8;
-///
-/// let parser = |s| {
-///   i8(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_31"},ignore
 /// ```
 #[inline]
 pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
@@ -823,24 +478,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i16 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i16 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::i16;
-///
-/// let be_i16 = |s| {
-///   i16(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_i16 = |s| {
-///   i16(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_32"},ignore
 /// ```
 #[inline]
 pub fn i16<I, E: ParseError<I>>(
@@ -857,24 +495,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i24 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::i24;
-///
-/// let be_i24 = |s| {
-///   i24(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_i24 = |s| {
-///   i24(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_33"},ignore
 /// ```
 #[inline]
 pub fn i24<I, E: ParseError<I>>(
@@ -891,24 +512,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i32 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::i32;
-///
-/// let be_i32 = |s| {
-///   i32(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_i32 = |s| {
-///   i32(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_34"},ignore
 /// ```
 #[inline]
 pub fn i32<I, E: ParseError<I>>(
@@ -925,24 +529,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i64 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::i64;
-///
-/// let be_i64 = |s| {
-///   i64(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_i64 = |s| {
-///   i64(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_35"},ignore
 /// ```
 #[inline]
 pub fn i64<I, E: ParseError<I>>(
@@ -959,24 +546,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i128 integer.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::i128;
-///
-/// let be_i128 = |s| {
-///   i128(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
-///
-/// let le_i128 = |s| {
-///   i128(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Error((&[0x01][..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_36"},ignore
 /// ```
 #[inline]
 pub fn i128<I, E: ParseError<I>>(
@@ -991,17 +561,7 @@ where
 /// Recognizes a big endian 4 bytes floating point number.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_f32;
-///
-/// let parser = |s| {
-///   be_f32(s)
-/// };
-///
-/// assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_37"},ignore
 /// ```
 #[inline]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
@@ -1017,17 +577,7 @@ where
 /// Recognizes a big endian 8 bytes floating point number.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::be_f64;
-///
-/// let parser = |s| {
-///   be_f64(s)
-/// };
-///
-/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_38"},ignore
 /// ```
 #[inline]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
@@ -1043,17 +593,7 @@ where
 /// Recognizes a little endian 4 bytes floating point number.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_f32;
-///
-/// let parser = |s| {
-///   le_f32(s)
-/// };
-///
-/// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_39"},ignore
 /// ```
 #[inline]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
@@ -1069,17 +609,7 @@ where
 /// Recognizes a little endian 8 bytes floating point number.
 ///
 /// *Complete version*: Returns an error if there is not enough input data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::le_f64;
-///
-/// let parser = |s| {
-///   le_f64(s)
-/// };
-///
-/// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_40"},ignore
 /// ```
 #[inline]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
@@ -1097,24 +627,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f32 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f32 float.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::f32;
-///
-/// let be_f32 = |s| {
-///   f32(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
-///
-/// let le_f32 = |s| {
-///   f32(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_41"},ignore
 /// ```
 #[inline]
 pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
@@ -1136,24 +649,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f64 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f64 float.
 /// *complete version*: returns an error if there is not enough input data
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::f64;
-///
-/// let be_f64 = |s| {
-///   f64(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
-///
-/// let le_f64 = |s| {
-///   f64(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Error((&b"abc"[..], ErrorKind::Eof))));
+/// ```rust,{source="doctests::example_42"},ignore
 /// ```
 #[inline]
 pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
@@ -1173,18 +669,7 @@ where
 /// Recognizes a hex-encoded integer.
 ///
 /// *Complete version*: Will parse until the end of input if it has less than 8 bytes.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::hex_u32;
-///
-/// let parser = |s| {
-///   hex_u32(s)
-/// };
-///
-/// assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
-/// assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// ```rust,{source="doctests::example_43"},ignore
 /// ```
 #[inline]
 pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -1227,19 +712,7 @@ where
 ///
 /// *Complete version*: Can parse until the end of input.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::recognize_float;
-///
-/// let parser = |s| {
-///   recognize_float(s)
-/// };
-///
-/// assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
-/// assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// ```rust,{source="doctests::example_44"},ignore
 /// ```
 #[rustfmt::skip]
 pub fn recognize_float<T, E:ParseError<T>>(input: T) -> IResult<T, T, E>
@@ -1391,19 +864,7 @@ use crate::traits::ParseTo;
 /// Recognizes floating point number in text format and returns a f32.
 ///
 /// *Complete version*: Can parse until the end of input.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::float;
-///
-/// let parser = |s| {
-///   float(s)
-/// };
-///
-/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
-/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// ```rust,{source="doctests::example_45"},ignore
 /// ```
 pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
@@ -1441,19 +902,7 @@ where
 /// Recognizes floating point number in text format and returns a f64.
 ///
 /// *Complete version*: Can parse until the end of input.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::double;
-///
-/// let parser = |s| {
-///   double(s)
-/// };
-///
-/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
-/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// ```rust,{source="doctests::example_46"},ignore
 /// ```
 pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
@@ -1967,4 +1416,811 @@ mod tests {
   //       assert_eq!(res1, res2);
   //   }
   // }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::Needed::Size;
+  use nom::{error::ErrorKind, Err, Needed};
+
+  #[test]
+  fn example_1() {
+    use nom::number::complete::be_u8;
+
+    let parser = |s| be_u8(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::number::complete::be_u16;
+
+    let parser = |s| be_u16(s);
+
+    assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::number::complete::be_u24;
+
+    let parser = |s| be_u24(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::number::complete::be_u32;
+
+    let parser = |s| be_u32(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::number::complete::be_u64;
+
+    let parser = |s| be_u64(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::number::complete::be_u128;
+
+    let parser = |s| be_u128(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::number::complete::be_i8;
+
+    let parser = |s| be_i8(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::number::complete::be_i16;
+
+    let parser = |s| be_i16(s);
+
+    assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::number::complete::be_i24;
+
+    let parser = |s| be_i24(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::number::complete::be_i32;
+
+    let parser = |s| be_i32(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::number::complete::be_i64;
+
+    let parser = |s| be_i64(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::number::complete::be_i128;
+
+    let parser = |s| be_i128(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::number::complete::le_u8;
+
+    let parser = |s| le_u8(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::number::complete::le_u16;
+
+    let parser = |s| le_u16(s);
+
+    assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_15() {
+    use nom::number::complete::le_u24;
+
+    let parser = |s| le_u24(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_16() {
+    use nom::number::complete::le_u32;
+
+    let parser = |s| le_u32(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_17() {
+    use nom::number::complete::le_u64;
+
+    let parser = |s| le_u64(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_18() {
+    use nom::number::complete::le_u128;
+
+    let parser = |s| le_u128(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_19() {
+    use nom::number::complete::le_i8;
+
+    let parser = |s| le_i8(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_20() {
+    use nom::number::complete::le_i16;
+
+    let parser = |s| le_i16(s);
+
+    assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_21() {
+    use nom::number::complete::le_i24;
+
+    let parser = |s| le_i24(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_22() {
+    use nom::number::complete::le_i32;
+
+    let parser = |s| le_i32(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_23() {
+    use nom::number::complete::le_i64;
+
+    let parser = |s| le_i64(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_24() {
+    use nom::number::complete::le_i128;
+
+    let parser = |s| le_i128(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(
+      parser(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_25() {
+    use nom::number::complete::u8;
+
+    let parser = |s| u8(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_26() {
+    use nom::number::complete::u16;
+
+    let be_u16 = |s| u16(nom::number::Endianness::Big)(s);
+
+    assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(
+      be_u16(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_u16 = |s| u16(nom::number::Endianness::Little)(s);
+
+    assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(
+      le_u16(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_27() {
+    use nom::number::complete::u24;
+
+    let be_u24 = |s| u24(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(
+      be_u24(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_u24 = |s| u24(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(
+      le_u24(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_28() {
+    use nom::number::complete::u32;
+
+    let be_u32 = |s| u32(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(
+      be_u32(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_u32 = |s| u32(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(
+      le_u32(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_29() {
+    use nom::number::complete::u64;
+
+    let be_u64 = |s| u64(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(
+      be_u64(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_u64 = |s| u64(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(
+      le_u64(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_30() {
+    use nom::number::complete::u128;
+
+    let be_u128 = |s| u128(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(
+      be_u128(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_u128 = |s| u128(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(
+      le_u128(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_31() {
+    use nom::number::complete::i8;
+
+    let parser = |s| i8(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Error((&[][..], ErrorKind::Eof))));
+  }
+
+  #[test]
+  fn example_32() {
+    use nom::number::complete::i16;
+
+    let be_i16 = |s| i16(nom::number::Endianness::Big)(s);
+
+    assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(
+      be_i16(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_i16 = |s| i16(nom::number::Endianness::Little)(s);
+
+    assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(
+      le_i16(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_33() {
+    use nom::number::complete::i24;
+
+    let be_i24 = |s| i24(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(
+      be_i24(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_i24 = |s| i24(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(
+      le_i24(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_34() {
+    use nom::number::complete::i32;
+
+    let be_i32 = |s| i32(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(
+      be_i32(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_i32 = |s| i32(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(
+      le_i32(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_35() {
+    use nom::number::complete::i64;
+
+    let be_i64 = |s| i64(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(
+      be_i64(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_i64 = |s| i64(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(
+      le_i64(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_36() {
+    use nom::number::complete::i128;
+
+    let be_i128 = |s| i128(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(
+      be_i128(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+
+    let le_i128 = |s| i128(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(
+      le_i128(&b"\x01"[..]),
+      Err(Err::Error((&[0x01][..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_37() {
+    use nom::number::complete::be_f32;
+
+    let parser = |s| be_f32(s);
+
+    assert_eq!(parser(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(
+      parser(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn exampe_38() {
+    use nom::number::complete::be_f64;
+
+    let parser = |s| be_f64(s);
+
+    assert_eq!(
+      parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(
+      parser(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_39() {
+    use nom::number::complete::le_f32;
+
+    let parser = |s| le_f32(s);
+
+    assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(
+      parser(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_40() {
+    use nom::number::complete::le_f64;
+
+    let parser = |s| le_f64(s);
+
+    assert_eq!(
+      parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(
+      parser(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_41() {
+    use nom::number::complete::f32;
+
+    let be_f32 = |s| f32(nom::number::Endianness::Big)(s);
+
+    assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(
+      be_f32(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+
+    let le_f32 = |s| f32(nom::number::Endianness::Little)(s);
+
+    assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(
+      le_f32(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_42() {
+    use nom::number::complete::f64;
+
+    let be_f64 = |s| f64(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(
+      be_f64(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+
+    let le_f64 = |s| f64(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(
+      le_f64(&b"abc"[..]),
+      Err(Err::Error((&b"abc"[..], ErrorKind::Eof)))
+    );
+  }
+
+  #[test]
+  fn example_43() {
+    use nom::number::complete::hex_u32;
+
+    let parser = |s| hex_u32(s);
+
+    assert_eq!(parser(&b"01AE"[..]), Ok((&b""[..], 0x01AE)));
+    assert_eq!(parser(&b"abc"[..]), Ok((&b""[..], 0x0ABC)));
+    assert_eq!(
+      parser(&b"ggg"[..]),
+      Err(Err::Error((&b"ggg"[..], ErrorKind::IsA)))
+    );
+  }
+
+  #[test]
+  fn example_44() {
+    use nom::number::complete::recognize_float;
+
+    let parser = |s| recognize_float(s);
+
+    assert_eq!(parser("11e-1"), Ok(("", "11e-1")));
+    assert_eq!(parser("123E-02"), Ok(("", "123E-02")));
+    assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+  }
+
+  #[test]
+  fn example_45() {
+    use nom::number::complete::float;
+
+    let parser = |s| float(s);
+
+    assert_eq!(parser("11e-1"), Ok(("", 1.1)));
+    assert_eq!(parser("123E-02"), Ok(("", 1.23)));
+    assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+  }
+
+  #[test]
+  fn example_46() {
+    use nom::number::complete::double;
+
+    let parser = |s| double(s);
+
+    assert_eq!(parser("11e-1"), Ok(("", 1.1)));
+    assert_eq!(parser("123E-02"), Ok(("", 1.23)));
+    assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+  }
 }

--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1493,7 +1493,7 @@ mod tests {
   use super::*;
   use crate::error::ErrorKind;
   use crate::internal::Err;
-  use proptest::prelude::*;
+  //use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -1957,14 +1957,14 @@ mod tests {
     }
   }
 
-  proptest! {
-    #[test]
-    #[cfg(feature = "std")]
-    fn floats(s in "\\PC*") {
-        println!("testing {}", s);
-        let res1 = parse_f64(&s);
-        let res2 = double::<_, ()>(s.as_str());
-        assert_eq!(res1, res2);
-    }
-  }
+  // proptest! {
+  //   #[test]
+  //   #[cfg(feature = "std")]
+  //   fn floats(s in "\\PC*") {
+  //       println!("testing {}", s);
+  //       let res1 = parse_f64(&s);
+  //       let res2 = double::<_, ()>(s.as_str());
+  //       assert_eq!(res1, res2);
+  //   }
+  // }
 }

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -99,16 +99,7 @@ where
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_u8;
-///
-/// let parser = |s| {
-///   be_u8::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[inline]
 pub fn be_u8<I, E: ParseError<I>>() -> impl Parser<I, Output = u8, Error = E>
@@ -120,16 +111,7 @@ where
 
 /// Recognizes a big endian unsigned 2 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_u16;
-///
-/// let parser = |s| {
-///   be_u16::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 #[inline]
 pub fn be_u16<I, E: ParseError<I>>() -> impl Parser<I, Output = u16, Error = E>
@@ -141,16 +123,7 @@ where
 
 /// Recognizes a big endian unsigned 3 byte integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_u24;
-///
-/// let parser = |s| {
-///   be_u24::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 #[inline]
 pub fn be_u24<I, E: ParseError<I>>() -> impl Parser<I, Output = u32, Error = E>
@@ -162,16 +135,7 @@ where
 
 /// Recognizes a big endian unsigned 4 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_u32;
-///
-/// let parser = |s| {
-///   be_u32::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 #[inline]
 pub fn be_u32<I, E: ParseError<I>>() -> impl Parser<I, Output = u32, Error = E>
@@ -183,16 +147,7 @@ where
 
 /// Recognizes a big endian unsigned 8 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_u64;
-///
-/// let parser = |s| {
-///   be_u64::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 #[inline]
 pub fn be_u64<I, E: ParseError<I>>() -> impl Parser<I, Output = u64, Error = E>
@@ -204,16 +159,7 @@ where
 
 /// Recognizes a big endian unsigned 16 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_u128;
-///
-/// let parser = |s| {
-///   be_u128::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 #[inline]
 pub fn be_u128<I, E: ParseError<I>>() -> impl Parser<I, Output = u128, Error = E>
@@ -226,14 +172,7 @@ where
 /// Recognizes a signed 1 byte integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_i8;
-///
-/// let mut parser = be_i8::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 #[inline]
 pub fn be_i8<I, E: ParseError<I>>() -> impl Parser<I, Output = i8, Error = E>
@@ -245,14 +184,7 @@ where
 
 /// Recognizes a big endian signed 2 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_i16;
-///
-/// let mut parser = be_i16::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 #[inline]
 pub fn be_i16<I, E: ParseError<I>>() -> impl Parser<I, Output = i16, Error = E>
@@ -264,14 +196,7 @@ where
 
 /// Recognizes a big endian signed 3 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_i24;
-///
-/// let mut parser = be_i24::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[inline]
 pub fn be_i24<I, E: ParseError<I>>() -> impl Parser<I, Output = i32, Error = E>
@@ -290,14 +215,7 @@ where
 
 /// Recognizes a big endian signed 4 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_i32;
-///
-/// let mut parser = be_i32::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 #[inline]
 pub fn be_i32<I, E: ParseError<I>>() -> impl Parser<I, Output = i32, Error = E>
@@ -309,14 +227,7 @@ where
 
 /// Recognizes a big endian signed 8 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_i64;
-///
-/// let mut parser = be_i64::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser.parse(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 #[inline]
 pub fn be_i64<I, E: ParseError<I>>() -> impl Parser<I, Output = i64, Error = E>
@@ -328,14 +239,7 @@ where
 
 /// Recognizes a big endian signed 16 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_i128;
-///
-/// let mut parser = be_i128::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser.parse(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 #[inline]
 pub fn be_i128<I, E: ParseError<I>>() -> impl Parser<I, Output = i128, Error = E>
@@ -407,14 +311,7 @@ where
 
 /// Recognizes an unsigned 1 byte integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_u8;
-///
-/// let mut parser = le_u8::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_13"},ignore
 /// ```
 #[inline]
 pub fn le_u8<I, E: ParseError<I>>() -> impl Parser<I, Output = u8, Error = E>
@@ -427,16 +324,7 @@ where
 /// Recognizes a little endian unsigned 2 bytes integer.
 ///
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_u16;
-///
-/// let parser = |s| {
-///   le_u16::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 #[inline]
 pub fn le_u16<I, E: ParseError<I>>() -> impl Parser<I, Output = u16, Error = E>
@@ -448,16 +336,7 @@ where
 
 /// Recognizes a little endian unsigned 3 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_u24;
-///
-/// let parser = |s| {
-///   le_u24::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 #[inline]
 pub fn le_u24<I, E: ParseError<I>>() -> impl Parser<I, Output = u32, Error = E>
@@ -469,16 +348,7 @@ where
 
 /// Recognizes a little endian unsigned 4 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_u32;
-///
-/// let parser = |s| {
-///   le_u32::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_16"},ignore
 /// ```
 #[inline]
 pub fn le_u32<I, E: ParseError<I>>() -> impl Parser<I, Output = u32, Error = E>
@@ -490,16 +360,7 @@ where
 
 /// Recognizes a little endian unsigned 8 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_u64;
-///
-/// let parser = |s| {
-///   le_u64::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 #[inline]
 pub fn le_u64<I, E: ParseError<I>>() -> impl Parser<I, Output = u64, Error = E>
@@ -511,16 +372,7 @@ where
 
 /// Recognizes a little endian unsigned 16 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_u128;
-///
-/// let mut parser = |s| {
-///   le_u128::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 #[inline]
 pub fn le_u128<I, E: ParseError<I>>() -> impl Parser<I, Output = u128, Error = E>
@@ -532,14 +384,7 @@ where
 
 /// Recognizes a signed 1 byte integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_i8;
-///
-/// let mut parser = le_i8::<_, (_, ErrorKind)>();
-///
-/// assert_eq!(parser.parse(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 #[inline]
 pub fn le_i8<I, E: ParseError<I>>() -> impl Parser<I, Output = i8, Error = E>
@@ -551,16 +396,7 @@ where
 
 /// Recognizes a little endian signed 2 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_i16;
-///
-/// let parser = |s| {
-///   le_i16::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 #[inline]
 pub fn le_i16<I, E: ParseError<I>>() -> impl Parser<I, Output = i16, Error = E>
@@ -572,16 +408,7 @@ where
 
 /// Recognizes a little endian signed 3 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_i24;
-///
-/// let parser = |s| {
-///   le_i24::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_21"},ignore
 /// ```
 #[inline]
 pub fn le_i24<I, E: ParseError<I>>() -> impl Parser<I, Output = i32, Error = E>
@@ -600,16 +427,7 @@ where
 
 /// Recognizes a little endian signed 4 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_i32;
-///
-/// let parser = |s| {
-///   le_i32::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_22"},ignore
 /// ```
 #[inline]
 pub fn le_i32<I, E: ParseError<I>>() -> impl Parser<I, Output = i32, Error = E>
@@ -621,16 +439,7 @@ where
 
 /// Recognizes a little endian signed 8 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_i64;
-///
-/// let parser = |s| {
-///   le_i64::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_23"},ignore
 /// ```
 #[inline]
 pub fn le_i64<I, E: ParseError<I>>() -> impl Parser<I, Output = i64, Error = E>
@@ -642,16 +451,7 @@ where
 
 /// Recognizes a little endian signed 16 bytes integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_i128;
-///
-/// let parser = |s| {
-///   le_i128::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_24"},ignore
 /// ```
 #[inline]
 pub fn le_i128<I, E: ParseError<I>>() -> impl Parser<I, Output = i128, Error = E>
@@ -664,17 +464,7 @@ where
 /// Recognizes an unsigned 1 byte integer
 ///
 /// Note that endianness does not apply to 1 byte numbers.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::u8;
-///
-/// let parser = |s| {
-///   u8::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_25"},ignore
 /// ```
 #[inline]
 pub fn u8<I, E: ParseError<I>>() -> impl Parser<I, Output = u8, Error = E>
@@ -689,24 +479,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u16 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u16 integer.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::u16;
-///
-/// let be_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
-///
-/// let le_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_26"},ignore
 /// ```
 #[inline]
 pub fn u16<I, E: ParseError<I>>(
@@ -729,24 +502,7 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u24 integer.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::u24;
-///
-/// let be_u24 = |s| {
-///   u24::<_,(_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
-///
-/// let le_u24 = |s| {
-///   u24::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_27"},ignore
 /// ```
 #[inline]
 pub fn u24<I, E: ParseError<I>>(
@@ -769,24 +525,7 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u32 integer.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::u32;
-///
-/// let be_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
-///
-/// let le_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_28"},ignore
 /// ```
 #[inline]
 pub fn u32<I, E: ParseError<I>>(
@@ -809,24 +548,7 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u64 integer.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::u64;
-///
-/// let be_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
-///
-/// let le_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_29"},ignore
 /// ```
 #[inline]
 pub fn u64<I, E: ParseError<I>>(
@@ -849,24 +571,7 @@ where
 ///
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u128 integer.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::u128;
-///
-/// let be_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
-///
-/// let le_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_30"},ignore
 /// ```
 #[inline]
 pub fn u128<I, E: ParseError<I>>(
@@ -889,17 +594,7 @@ where
 ///
 /// Note that endianness does not apply to 1 byte numbers.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::i8;
-///
-/// let parser = |s| {
-///   i8::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_31"},ignore
 /// ```
 #[inline]
 pub fn i8<I, E: ParseError<I>>() -> impl Parser<I, Output = i8, Error = E>
@@ -914,24 +609,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i16 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i16 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::i16;
-///
-/// let be_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
-///
-/// let le_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_32"},ignore
 /// ```
 #[inline]
 pub fn i16<I, E: ParseError<I>>(
@@ -955,24 +633,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i24 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::i24;
-///
-/// let be_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
-///
-/// let le_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_33"},ignore
 /// ```
 #[inline]
 pub fn i24<I, E: ParseError<I>>(
@@ -996,24 +657,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i32 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::i32;
-///
-/// let be_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
-///
-/// let le_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_34"},ignore
 /// ```
 #[inline]
 pub fn i32<I, E: ParseError<I>>(
@@ -1037,24 +681,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i64 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::i64;
-///
-/// let be_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
-///
-/// let le_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_35"},ignore
 /// ```
 #[inline]
 pub fn i64<I, E: ParseError<I>>(
@@ -1078,24 +705,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i128 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::i128;
-///
-/// let be_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
-///
-/// let le_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_36"},ignore
 /// ```
 #[inline]
 pub fn i128<I, E: ParseError<I>>(
@@ -1117,16 +727,7 @@ where
 /// Recognizes a big endian 4 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_f32;
-///
-/// let parser = |s| {
-///   be_f32::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00][..]), Ok((&b""[..], 2.640625)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_37"},ignore
 /// ```
 #[inline]
 pub fn be_f32<I, E: ParseError<I>>() -> impl Parser<I, Output = f32, Error = E>
@@ -1139,16 +740,7 @@ where
 /// Recognizes a big endian 8 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::be_f64;
-///
-/// let parser = |s| {
-///   be_f64::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_38"},ignore
 /// ```
 #[inline]
 pub fn be_f64<I, E: ParseError<I>>() -> impl Parser<I, Output = f64, Error = E>
@@ -1161,16 +753,7 @@ where
 /// Recognizes a little endian 4 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_f32;
-///
-/// let parser = |s| {
-///   le_f32::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_39"},ignore
 /// ```
 #[inline]
 pub fn le_f32<I, E: ParseError<I>>() -> impl Parser<I, Output = f32, Error = E>
@@ -1183,16 +766,7 @@ where
 /// Recognizes a little endian 8 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::le_f64;
-///
-/// let parser = |s| {
-///   le_f64::<_, (_, ErrorKind)>().parse(s)
-/// };
-///
-/// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 3145728.0)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_40"},ignore
 /// ```
 #[inline]
 pub fn le_f64<I, E: ParseError<I>>() -> impl Parser<I, Output = f64, Error = E>
@@ -1207,24 +781,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f32 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f32 float.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::f32;
-///
-/// let be_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
-///
-/// let le_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{soruce="doctests::example_41"},ignore
 /// ```
 #[inline]
 pub fn f32<I, E: ParseError<I>>(
@@ -1248,24 +805,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f64 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f64 float.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::number::f64;
-///
-/// let be_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s)
-/// };
-///
-/// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
-///
-/// let le_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s)
-/// };
-///
-/// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+/// ```rust,{source="doctests::example_42"},ignore
 /// ```
 #[inline]
 pub fn f64<I, E: ParseError<I>>(
@@ -1288,18 +828,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if it reaches the end of input.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// use nom::number::recognize_float;
-///
-/// let parser = |s| {
-///   recognize_float().parse(s)
-/// };
-///
-/// assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
-/// assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// ```rust,{source="doctests::example_43"},ignore
 /// ```
 #[rustfmt::skip]
 pub fn recognize_float<T, E:ParseError<T>>() -> impl Parser<T, Output=T,Error= E>
@@ -1478,5 +1007,637 @@ mod tests {
     let (i, inf) = float::<_, ()>("infinity").unwrap();
     assert!(inf.is_infinite());
     assert!(i.is_empty());*/
+  }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::{error::ErrorKind, Err, Needed, Parser};
+  #[test]
+  fn example_1() {
+    use nom::number::be_u8;
+
+    let parser = |s| be_u8::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::number::be_u16;
+
+    let parser = |s| be_u16::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::number::be_u24;
+
+    let parser = |s| be_u24::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x000102))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::number::be_u32;
+
+    let parser = |s| be_u32::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::number::be_u64;
+
+    let parser = |s| be_u64::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0001020304050607))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::number::be_u128;
+
+    let parser = |s| be_u128::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203040506070809101112131415))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::number::be_i8;
+
+    let mut parser = be_i8::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01abcd"[..]),
+      Ok((&b"\x01abcd"[..], 0x00))
+    );
+    assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::number::be_i16;
+
+    let mut parser = be_i16::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01abcd"[..]),
+      Ok((&b"abcd"[..], 0x0001))
+    );
+    assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::number::be_i24;
+
+    let mut parser = be_i24::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x000102))
+    );
+    assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::number::be_i32;
+
+    let mut parser = be_i32::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203))
+    );
+    assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::number::be_i64;
+
+    let mut parser = be_i64::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0001020304050607))
+    );
+    assert_eq!(
+      parser.parse(&b"\x01"[..]),
+      Err(Err::Incomplete(Needed::new(7)))
+    );
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::number::be_i128;
+
+    let mut parser = be_i128::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203040506070809101112131415))
+    );
+    assert_eq!(
+      parser.parse(&b"\x01"[..]),
+      Err(Err::Incomplete(Needed::new(15)))
+    );
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::number::le_u8;
+
+    let mut parser = le_u8::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01abcd"[..]),
+      Ok((&b"\x01abcd"[..], 0x00))
+    );
+    assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::number::le_u16;
+
+    let parser = |s| le_u16::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_15() {
+    use nom::number::le_u24;
+
+    let parser = |s| le_u24::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_16() {
+    use nom::number::le_u32;
+
+    let parser = |s| le_u32::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x03020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_17() {
+    use nom::number::le_u64;
+
+    let parser = |s| le_u64::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_18() {
+    use nom::number::le_u128;
+
+    let mut parser = |s| le_u128::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x15141312111009080706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_19() {
+    use nom::number::le_i8;
+
+    let mut parser = le_i8::<_, (_, ErrorKind)>();
+
+    assert_eq!(
+      parser.parse(&b"\x00\x01abcd"[..]),
+      Ok((&b"\x01abcd"[..], 0x00))
+    );
+    assert_eq!(parser.parse(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_20() {
+    use nom::number::le_i16;
+
+    let parser = |s| le_i16::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_21() {
+    use nom::number::le_i24;
+
+    let parser = |s| le_i24::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_22() {
+    use nom::number::le_i32;
+
+    let parser = |s| le_i32::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x03020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_23() {
+    use nom::number::le_i64;
+
+    let parser = |s| le_i64::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_24() {
+    use nom::number::le_i128;
+
+    let parser = |s| le_i128::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x15141312111009080706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_25() {
+    use nom::number::u8;
+
+    let parser = |s| u8::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_26() {
+    use nom::number::u16;
+
+    let be_u16 = |s| u16::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+
+    let le_u16 = |s| u16::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_27() {
+    use nom::number::u24;
+
+    let be_u24 = |s| u24::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_u24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+
+    let le_u24 = |s| u24::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_u24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_28() {
+    use nom::number::u32;
+
+    let be_u32 = |s| u32::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_u32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+
+    let le_u32 = |s| u32::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_u32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_29() {
+    use nom::number::u64;
+
+    let be_u64 = |s| u64::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+
+    let le_u64 = |s| u64::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_30() {
+    use nom::number::u128;
+
+    let be_u128 = |s| u128::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+
+    let le_u128 = |s| u128::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_31() {
+    use nom::number::i8;
+
+    let parser = |s| i8::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_32() {
+    use nom::number::i16;
+
+    let be_i16 = |s| i16::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+
+    let le_i16 = |s| i16::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_33() {
+    use nom::number::i24;
+
+    let be_i24 = |s| i24::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_i24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+
+    let le_i24 = |s| i24::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_i24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_34() {
+    use nom::number::i32;
+
+    let be_i32 = |s| i32::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_i32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+
+    let le_i32 = |s| i32::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_i32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_35() {
+    use nom::number::i64;
+
+    let be_i64 = |s| i64::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+
+    let le_i64 = |s| i64::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_36() {
+    use nom::number::i128;
+
+    let be_i128 = |s| i128::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+
+    let le_i128 = |s| i128::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_37() {
+    use nom::number::be_f32;
+
+    let parser = |s| be_f32::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&[0x40, 0x29, 0x00, 0x00][..]),
+      Ok((&b""[..], 2.640625))
+    );
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_38() {
+    use nom::number::be_f64;
+
+    let parser = |s| be_f64::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_39() {
+    use nom::number::le_f32;
+
+    let parser = |s| le_f32::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_40() {
+    use nom::number::le_f64;
+
+    let parser = |s| le_f64::<_, (_, ErrorKind)>().parse(s);
+
+    assert_eq!(
+      parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]),
+      Ok((&b""[..], 3145728.0))
+    );
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_41() {
+    use nom::number::f32;
+
+    let be_f32 = |s| f32::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+
+    let le_f32 = |s| f32::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_42() {
+    use nom::number::f64;
+
+    let be_f64 = |s| f64::<_, (_, ErrorKind)>(nom::number::Endianness::Big).parse(s);
+
+    assert_eq!(
+      be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+
+    let le_f64 = |s| f64::<_, (_, ErrorKind)>(nom::number::Endianness::Little).parse(s);
+
+    assert_eq!(
+      le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+  }
+
+  #[test]
+  fn example_43() {
+    use nom::number::recognize_float;
+
+    let parser = |s| recognize_float().parse(s);
+
+    assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
+    assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
+    assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
   }
 }

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -1461,7 +1461,7 @@ mod tests {
   use super::*;
   use crate::error::ErrorKind;
   use crate::internal::{Err, Needed};
-  use proptest::prelude::*;
+  //use proptest::prelude::*;
 
   macro_rules! assert_parse(
     ($left: expr, $right: expr) => {
@@ -2053,14 +2053,14 @@ mod tests {
     }
   }
 
-  proptest! {
-    #[test]
-    #[cfg(feature = "std")]
-    fn floats(s in "\\PC*") {
-        println!("testing {}", s);
-        let res1 = parse_f64(&s);
-        let res2 = double::<_, ()>(s.as_str());
-        assert_eq!(res1, res2);
-    }
-  }
+  // proptest! {
+  //   #[test]
+  //   #[cfg(feature = "std")]
+  //   fn floats(s in "\\PC*") {
+  //       println!("testing {}", s);
+  //       let res1 = parse_f64(&s);
+  //       let res2 = double::<_, ()>(s.as_str());
+  //       assert_eq!(res1, res2);
+  //   }
+  // }
 }

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -13,16 +13,7 @@ use crate::{internal::*, Input};
 /// Recognizes an unsigned 1 byte integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_u8;
-///
-/// let parser = |s| {
-///   be_u8::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 #[inline]
 pub fn be_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -36,16 +27,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_u16;
-///
-/// let parser = |s| {
-///   be_u16::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 #[inline]
 pub fn be_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
@@ -59,16 +41,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_u24;
-///
-/// let parser = |s| {
-///   be_u24::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{soruce="doctests::example_3"},ignore
 /// ```
 #[inline]
 pub fn be_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -82,16 +55,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_u32;
-///
-/// let parser = |s| {
-///   be_u32::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 #[inline]
 pub fn be_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -105,16 +69,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_u64;
-///
-/// let parser = |s| {
-///   be_u64::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 #[inline]
 pub fn be_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
@@ -127,16 +82,7 @@ where
 /// Recognizes a big endian unsigned 16 bytes integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_u128;
-///
-/// let parser = |s| {
-///   be_u128::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_6"},ignore
 /// ```
 #[inline]
 pub fn be_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
@@ -158,14 +104,7 @@ where
 /// Recognizes a signed 1 byte integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_i8;
-///
-/// let parser = be_i8::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_7"},ignore
 /// ```
 #[inline]
 pub fn be_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -178,14 +117,7 @@ where
 /// Recognizes a big endian signed 2 bytes integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_i16;
-///
-/// let parser = be_i16::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_8"},ignore
 /// ```
 #[inline]
 pub fn be_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
@@ -198,14 +130,7 @@ where
 /// Recognizes a big endian signed 3 bytes integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_i24;
-///
-/// let parser = be_i24::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x000102)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_9"},ignore
 /// ```
 #[inline]
 pub fn be_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -227,14 +152,7 @@ where
 /// Recognizes a big endian signed 4 bytes integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_i32;
-///
-/// let parser = be_i32::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x00010203)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
+/// ```rust,{source="doctests::example_10"},ignore
 /// ```
 #[inline]
 pub fn be_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -248,14 +166,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_i64;
-///
-/// let parser = be_i64::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0001020304050607)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_11"},ignore
 /// ```
 #[inline]
 pub fn be_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
@@ -268,14 +179,7 @@ where
 /// Recognizes a big endian signed 16 bytes integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_i128;
-///
-/// let parser = be_i128::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x00010203040506070809101112131415)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_12"},ignore
 /// ```
 #[inline]
 pub fn be_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
@@ -288,14 +192,7 @@ where
 /// Recognizes an unsigned 1 byte integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_u8;
-///
-/// let parser = le_u8::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{soruce="doctests::example_13"},ignore
 /// ```
 #[inline]
 pub fn le_u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -309,16 +206,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_u16;
-///
-/// let parser = |s| {
-///   le_u16::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_14"},ignore
 /// ```
 #[inline]
 pub fn le_u16<I, E: ParseError<I>>(input: I) -> IResult<I, u16, E>
@@ -332,16 +220,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_u24;
-///
-/// let parser = |s| {
-///   le_u24::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_15"},ignore
 /// ```
 #[inline]
 pub fn le_u24<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -355,16 +234,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_u32;
-///
-/// let parser = |s| {
-///   le_u32::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_16"},ignore
 /// ```
 #[inline]
 pub fn le_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -378,16 +248,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_u64;
-///
-/// let parser = |s| {
-///   le_u64::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_17"},ignore
 /// ```
 #[inline]
 pub fn le_u64<I, E: ParseError<I>>(input: I) -> IResult<I, u64, E>
@@ -401,16 +262,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_u128;
-///
-/// let parser = |s| {
-///   le_u128::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_18"},ignore
 /// ```
 #[inline]
 pub fn le_u128<I, E: ParseError<I>>(input: I) -> IResult<I, u128, E>
@@ -432,14 +284,7 @@ where
 /// Recognizes a signed 1 byte integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_i8;
-///
-/// let parser = le_i8::<_, (_, ErrorKind)>;
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_19"},ignore
 /// ```
 #[inline]
 pub fn le_i8<I, E: ParseError<I>>(input: I) -> IResult<I, i8, E>
@@ -453,16 +298,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_i16;
-///
-/// let parser = |s| {
-///   le_i16::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_20"},ignore
 /// ```
 #[inline]
 pub fn le_i16<I, E: ParseError<I>>(input: I) -> IResult<I, i16, E>
@@ -476,16 +312,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_i24;
-///
-/// let parser = |s| {
-///   le_i24::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02abcd"[..]), Ok((&b"abcd"[..], 0x020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_21"},ignore
 /// ```
 #[inline]
 pub fn le_i24<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -508,16 +335,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_i32;
-///
-/// let parser = |s| {
-///   le_i32::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03abcd"[..]), Ok((&b"abcd"[..], 0x03020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_22"},ignore
 /// ```
 #[inline]
 pub fn le_i32<I, E: ParseError<I>>(input: I) -> IResult<I, i32, E>
@@ -531,16 +349,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_i64;
-///
-/// let parser = |s| {
-///   le_i64::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]), Ok((&b"abcd"[..], 0x0706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_23"},ignore
 /// ```
 #[inline]
 pub fn le_i64<I, E: ParseError<I>>(input: I) -> IResult<I, i64, E>
@@ -554,16 +363,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_i128;
-///
-/// let parser = |s| {
-///   le_i128::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]), Ok((&b"abcd"[..], 0x15141312111009080706050403020100)));
-/// assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_24"},ignore
 /// ```
 #[inline]
 pub fn le_i128<I, E: ParseError<I>>(input: I) -> IResult<I, i128, E>
@@ -577,17 +377,7 @@ where
 ///
 /// Note that endianness does not apply to 1 byte numbers.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::u8;
-///
-/// let parser = |s| {
-///   u8::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_25"},ignore
 /// ```
 #[inline]
 pub fn u8<I, E: ParseError<I>>(input: I) -> IResult<I, u8, E>
@@ -603,24 +393,7 @@ where
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u16 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::u16;
-///
-/// let be_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
-///
-/// let le_u16 = |s| {
-///   u16::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_26"},ignore
 /// ```
 #[inline]
 pub fn u16<I, E: ParseError<I>>(
@@ -637,24 +410,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u24 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::u24;
-///
-/// let be_u24 = |s| {
-///   u24::<_,(_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
-///
-/// let le_u24 = |s| {
-///   u24::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_27"},ignore
 /// ```
 #[inline]
 pub fn u24<I, E: ParseError<I>>(
@@ -671,24 +427,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u32 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::u32;
-///
-/// let be_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
-///
-/// let le_u32 = |s| {
-///   u32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_28"},ignore
 /// ```
 #[inline]
 pub fn u32<I, E: ParseError<I>>(
@@ -705,24 +444,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u64 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::u64;
-///
-/// let be_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
-///
-/// let le_u64 = |s| {
-///   u64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_29"},ignore
 /// ```
 #[inline]
 pub fn u64<I, E: ParseError<I>>(
@@ -739,24 +461,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian u128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian u128 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::u128;
-///
-/// let be_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
-///
-/// let le_u128 = |s| {
-///   u128::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_30"},ignore
 /// ```
 #[inline]
 pub fn u128<I, E: ParseError<I>>(
@@ -772,17 +477,7 @@ where
 ///
 /// Note that endianness does not apply to 1 byte numbers.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::i8;
-///
-/// let parser = |s| {
-///   i8::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&b"\x00\x03abcefg"[..]), Ok((&b"\x03abcefg"[..], 0x00)));
-/// assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_31"},ignore
 /// ```
 #[inline]
 pub fn i8<I, E: ParseError<I>>(i: I) -> IResult<I, i8, E>
@@ -797,24 +492,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i16 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i16 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::i16;
-///
-/// let be_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
-/// assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
-///
-/// let le_i16 = |s| {
-///   i16::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
-/// assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_32"},ignore
 /// ```
 #[inline]
 pub fn i16<I, E: ParseError<I>>(
@@ -831,24 +509,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i24 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i24 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::i24;
-///
-/// let be_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x000305)));
-/// assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
-///
-/// let le_i24 = |s| {
-///   i24::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i24(&b"\x00\x03\x05abcefg"[..]), Ok((&b"abcefg"[..], 0x050300)));
-/// assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+/// ```rust,{source="doctests::example_33"},ignore
 /// ```
 #[inline]
 pub fn i24<I, E: ParseError<I>>(
@@ -865,24 +526,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i32 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i32 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::i32;
-///
-/// let be_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00030507)));
-/// assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
-///
-/// let le_i32 = |s| {
-///   i32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i32(&b"\x00\x03\x05\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07050300)));
-/// assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_34"},ignore
 /// ```
 #[inline]
 pub fn i32<I, E: ParseError<I>>(
@@ -899,24 +543,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i64 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i64 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::i64;
-///
-/// let be_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0001020304050607)));
-/// assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
-///
-/// let le_i64 = |s| {
-///   i64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x0706050403020100)));
-/// assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{sourc="doctests::example_35"},ignore
 /// ```
 #[inline]
 pub fn i64<I, E: ParseError<I>>(
@@ -933,24 +560,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian i128 integer,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian i128 integer.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::i128;
-///
-/// let be_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x00010203040506070001020304050607)));
-/// assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
-///
-/// let le_i128 = |s| {
-///   i128::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]), Ok((&b"abcefg"[..], 0x07060504030201000706050403020100)));
-/// assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+/// ```rust,{source="doctests::example_36"},ignore
 /// ```
 #[inline]
 pub fn i128<I, E: ParseError<I>>(
@@ -965,16 +575,7 @@ where
 /// Recognizes a big endian 4 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_f32;
-///
-/// let parser = |s| {
-///   be_f32::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00][..]), Ok((&b""[..], 2.640625)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_37"},ignore
 /// ```
 #[inline]
 pub fn be_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
@@ -990,16 +591,7 @@ where
 /// Recognizes a big endian 8 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::be_f64;
-///
-/// let parser = |s| {
-///   be_f64::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_38"},ignore
 /// ```
 #[inline]
 pub fn be_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
@@ -1015,16 +607,7 @@ where
 /// Recognizes a little endian 4 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_f32;
-///
-/// let parser = |s| {
-///   le_f32::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+/// ```rust,{source="doctests::example_39"},ignore
 /// ```
 #[inline]
 pub fn le_f32<I, E: ParseError<I>>(input: I) -> IResult<I, f32, E>
@@ -1040,16 +623,7 @@ where
 /// Recognizes a little endian 8 bytes floating point number.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::le_f64;
-///
-/// let parser = |s| {
-///   le_f64::<_, (_, ErrorKind)>(s)
-/// };
-///
-/// assert_eq!(parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 3145728.0)));
-/// assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+/// ```rust,{source="doctests::example_40"},ignore
 /// ```
 #[inline]
 pub fn le_f64<I, E: ParseError<I>>(input: I) -> IResult<I, f64, E>
@@ -1067,24 +641,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f32 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f32 float.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::f32;
-///
-/// let be_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
-///
-/// let le_f32 = |s| {
-///   f32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+/// ```rust,{source="doctests::example_41"},ignore
 /// ```
 #[inline]
 pub fn f32<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f32, E>
@@ -1106,24 +663,7 @@ where
 /// If the parameter is `nom::number::Endianness::Big`, parse a big endian f64 float,
 /// otherwise if `nom::number::Endianness::Little` parse a little endian f64 float.
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::streaming::f64;
-///
-/// let be_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s)
-/// };
-///
-/// assert_eq!(be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
-///
-/// let le_f64 = |s| {
-///   f64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s)
-/// };
-///
-/// assert_eq!(le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]), Ok((&b""[..], 12.5)));
-/// assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+/// ```rust,{source="doctests::example_42"},ignore
 /// ```
 #[inline]
 pub fn f64<I, E: ParseError<I>>(endian: crate::number::Endianness) -> fn(I) -> IResult<I, f64, E>
@@ -1143,17 +683,7 @@ where
 /// Recognizes a hex-encoded integer.
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::hex_u32;
-///
-/// let parser = |s| {
-///   hex_u32(s)
-/// };
-///
-/// assert_eq!(parser(&b"01AE;"[..]), Ok((&b";"[..], 0x01AE)));
-/// assert_eq!(parser(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
-/// assert_eq!(parser(&b"ggg"[..]), Err(Err::Error((&b"ggg"[..], ErrorKind::IsA))));
+/// ```rust,{source="doctests::example_43"},ignore
 /// ```
 #[inline]
 pub fn hex_u32<I, E: ParseError<I>>(input: I) -> IResult<I, u32, E>
@@ -1195,18 +725,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if it reaches the end of input.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// use nom::number::streaming::recognize_float;
-///
-/// let parser = |s| {
-///   recognize_float(s)
-/// };
-///
-/// assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
-/// assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+/// ```rust,{source="doctests::example_44"},ignore
 /// ```
 #[rustfmt::skip]
 pub fn recognize_float<T, E:ParseError<T>>(input: T) -> IResult<T, T, E>
@@ -1360,19 +879,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::float;
-///
-/// let parser = |s| {
-///   float(s)
-/// };
-///
-/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
-/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// ```rust,{source="doctests::example_45"},ignore
 /// ```
 pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
@@ -1410,19 +917,7 @@ where
 ///
 /// *Streaming version*: Will return `Err(nom::Err::Incomplete(_))` if there is not enough data.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed};
-/// # use nom::Needed::Size;
-/// use nom::number::complete::double;
-///
-/// let parser = |s| {
-///   double(s)
-/// };
-///
-/// assert_eq!(parser("11e-1"), Ok(("", 1.1)));
-/// assert_eq!(parser("123E-02"), Ok(("", 1.23)));
-/// assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
-/// assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+/// ```rust,{source="doctests::example_46"},ignore
 /// ```
 pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
@@ -2063,4 +1558,657 @@ mod tests {
   //       assert_eq!(res1, res2);
   //   }
   // }
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::{error::ErrorKind, Err, Needed};
+
+  #[test]
+  fn example_1() {
+    use nom::number::streaming::be_u8;
+
+    let parser = |s| be_u8::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::number::streaming::be_u16;
+
+    let parser = |s| be_u16::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::number::streaming::be_u24;
+
+    let parser = |s| be_u24::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x000102))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::number::streaming::be_u32;
+
+    let parser = |s| be_u32::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::number::streaming::be_u64;
+
+    let parser = |s| be_u64::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0001020304050607))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::number::streaming::be_u128;
+
+    let parser = |s| be_u128::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203040506070809101112131415))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_7() {
+    use nom::number::streaming::be_i8;
+
+    let parser = be_i8::<_, (_, ErrorKind)>;
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_8() {
+    use nom::number::streaming::be_i16;
+
+    let parser = be_i16::<_, (_, ErrorKind)>;
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0001)));
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_9() {
+    use nom::number::streaming::be_i24;
+
+    let parser = be_i24::<_, (_, ErrorKind)>;
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x000102))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_10() {
+    use nom::number::streaming::be_i32;
+
+    let parser = be_i32::<_, (_, ErrorKind)>;
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(4))));
+  }
+
+  #[test]
+  fn example_11() {
+    use nom::number::streaming::be_i64;
+
+    let parser = be_i64::<_, (_, ErrorKind)>;
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0001020304050607))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_12() {
+    use nom::number::streaming::be_i128;
+
+    let parser = be_i128::<_, (_, ErrorKind)>;
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x00010203040506070809101112131415))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_13() {
+    use nom::number::streaming::le_u8;
+
+    let parser = le_u8::<_, (_, ErrorKind)>;
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_14() {
+    use nom::number::streaming::le_u16;
+
+    let parser = |s| le_u16::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_15() {
+    use nom::number::streaming::le_u24;
+
+    let parser = |s| le_u24::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_16() {
+    use nom::number::streaming::le_u32;
+
+    let parser = |s| le_u32::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x03020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_17() {
+    use nom::number::streaming::le_u64;
+
+    let parser = |s| le_u64::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_18() {
+    use nom::number::streaming::le_u128;
+
+    let parser = |s| le_u128::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x15141312111009080706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_19() {
+    use nom::number::streaming::le_i8;
+
+    let parser = le_i8::<_, (_, ErrorKind)>;
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"\x01abcd"[..], 0x00)));
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_20() {
+    use nom::number::streaming::le_i16;
+
+    let parser = |s| le_i16::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(parser(&b"\x00\x01abcd"[..]), Ok((&b"abcd"[..], 0x0100)));
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_21() {
+    use nom::number::streaming::le_i24;
+
+    let parser = |s| le_i24::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02abcd"[..]),
+      Ok((&b"abcd"[..], 0x020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_22() {
+    use nom::number::streaming::le_i32;
+
+    let parser = |s| le_i32::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03abcd"[..]),
+      Ok((&b"abcd"[..], 0x03020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_23() {
+    use nom::number::streaming::le_i64;
+
+    let parser = |s| le_i64::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcd"[..]),
+      Ok((&b"abcd"[..], 0x0706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_24() {
+    use nom::number::streaming::le_i128;
+
+    let parser = |s| le_i128::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15abcd"[..]),
+      Ok((&b"abcd"[..], 0x15141312111009080706050403020100))
+    );
+    assert_eq!(parser(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_25() {
+    use nom::number::streaming::u8;
+
+    let parser = |s| u8::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_26() {
+    use nom::number::streaming::u16;
+
+    let be_u16 = |s| u16::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(be_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(be_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+
+    let le_u16 = |s| u16::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(le_u16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(le_u16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_27() {
+    use nom::number::streaming::u24;
+
+    let be_u24 = |s| u24::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(be_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+
+    let le_u24 = |s| u24::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(le_u24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_28() {
+    use nom::number::streaming::u32;
+
+    let be_u32 = |s| u32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(be_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+
+    let le_u32 = |s| u32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(le_u32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_29() {
+    use nom::number::streaming::u64;
+
+    let be_u64 = |s| u64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(be_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+
+    let le_u64 = |s| u64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(le_u64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_30() {
+    use nom::number::streaming::u128;
+
+    let be_u128 = |s| u128::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(be_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+
+    let le_u128 = |s| u128::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_u128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(le_u128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_31() {
+    use nom::number::streaming::i8;
+
+    let parser = |s| i8::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&b"\x00\x03abcefg"[..]),
+      Ok((&b"\x03abcefg"[..], 0x00))
+    );
+    assert_eq!(parser(&b""[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_32() {
+    use nom::number::streaming::i16;
+
+    let be_i16 = |s| i16::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(be_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0003)));
+    assert_eq!(be_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+
+    let le_i16 = |s| i16::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(le_i16(&b"\x00\x03abcefg"[..]), Ok((&b"abcefg"[..], 0x0300)));
+    assert_eq!(le_i16(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_33() {
+    use nom::number::streaming::i24;
+
+    let be_i24 = |s| i24::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x000305))
+    );
+    assert_eq!(be_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+
+    let le_i24 = |s| i24::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i24(&b"\x00\x03\x05abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x050300))
+    );
+    assert_eq!(le_i24(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(2))));
+  }
+
+  #[test]
+  fn example_34() {
+    use nom::number::streaming::i32;
+
+    let be_i32 = |s| i32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00030507))
+    );
+    assert_eq!(be_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+
+    let le_i32 = |s| i32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i32(&b"\x00\x03\x05\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07050300))
+    );
+    assert_eq!(le_i32(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_35() {
+    use nom::number::streaming::i64;
+
+    let be_i64 = |s| i64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0001020304050607))
+    );
+    assert_eq!(be_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+
+    let le_i64 = |s| i64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i64(&b"\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x0706050403020100))
+    );
+    assert_eq!(le_i64(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_36() {
+    use nom::number::streaming::i128;
+
+    let be_i128 = |s| i128::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x00010203040506070001020304050607))
+    );
+    assert_eq!(be_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+
+    let le_i128 = |s| i128::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_i128(&b"\x00\x01\x02\x03\x04\x05\x06\x07\x00\x01\x02\x03\x04\x05\x06\x07abcefg"[..]),
+      Ok((&b"abcefg"[..], 0x07060504030201000706050403020100))
+    );
+    assert_eq!(le_i128(&b"\x01"[..]), Err(Err::Incomplete(Needed::new(15))));
+  }
+
+  #[test]
+  fn example_37() {
+    use nom::number::streaming::be_f32;
+
+    let parser = |s| be_f32::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&[0x40, 0x29, 0x00, 0x00][..]),
+      Ok((&b""[..], 2.640625))
+    );
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_38() {
+    use nom::number::streaming::be_f64;
+
+    let parser = |s| be_f64::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_39() {
+    use nom::number::streaming::le_f32;
+
+    let parser = |s| le_f32::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(parser(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(3))));
+  }
+
+  #[test]
+  fn example_40() {
+    use nom::number::streaming::le_f64;
+
+    let parser = |s| le_f64::<_, (_, ErrorKind)>(s);
+
+    assert_eq!(
+      parser(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x48, 0x41][..]),
+      Ok((&b""[..], 3145728.0))
+    );
+    assert_eq!(parser(&[0x01][..]), Err(Err::Incomplete(Needed::new(7))));
+  }
+
+  #[test]
+  fn example_41() {
+    use nom::number::streaming::f32;
+
+    let be_f32 = |s| f32::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(be_f32(&[0x41, 0x48, 0x00, 0x00][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(be_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+
+    let le_f32 = |s| f32::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(le_f32(&[0x00, 0x00, 0x48, 0x41][..]), Ok((&b""[..], 12.5)));
+    assert_eq!(le_f32(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+  }
+
+  #[test]
+  fn example_42() {
+    use nom::number::streaming::f64;
+
+    let be_f64 = |s| f64::<_, (_, ErrorKind)>(nom::number::Endianness::Big)(s);
+
+    assert_eq!(
+      be_f64(&[0x40, 0x29, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(be_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+
+    let le_f64 = |s| f64::<_, (_, ErrorKind)>(nom::number::Endianness::Little)(s);
+
+    assert_eq!(
+      le_f64(&[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x29, 0x40][..]),
+      Ok((&b""[..], 12.5))
+    );
+    assert_eq!(le_f64(&b"abc"[..]), Err(Err::Incomplete(Needed::new(5))));
+  }
+
+  #[test]
+  fn example_43() {
+    use nom::number::streaming::hex_u32;
+
+    let parser = |s| hex_u32(s);
+
+    assert_eq!(parser(&b"01AE;"[..]), Ok((&b";"[..], 0x01AE)));
+    assert_eq!(parser(&b"abc"[..]), Err(Err::Incomplete(Needed::new(1))));
+    assert_eq!(
+      parser(&b"ggg"[..]),
+      Err(Err::Error((&b"ggg"[..], ErrorKind::IsA)))
+    );
+  }
+
+  #[test]
+  fn example_44() {
+    use nom::number::streaming::recognize_float;
+
+    let parser = |s| recognize_float(s);
+
+    assert_eq!(parser("11e-1;"), Ok((";", "11e-1")));
+    assert_eq!(parser("123E-02;"), Ok((";", "123E-02")));
+    assert_eq!(parser("123K-01"), Ok(("K-01", "123")));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Char))));
+  }
+
+  #[test]
+  fn example_45() {
+    use nom::number::complete::float;
+
+    let parser = |s| float(s);
+
+    assert_eq!(parser("11e-1"), Ok(("", 1.1)));
+    assert_eq!(parser("123E-02"), Ok(("", 1.23)));
+    assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+  }
+
+  #[test]
+  fn example_46() {
+    use nom::number::complete::double;
+
+    let parser = |s| double(s);
+
+    assert_eq!(parser("11e-1"), Ok(("", 1.1)));
+    assert_eq!(parser("123E-02"), Ok(("", 1.23)));
+    assert_eq!(parser("123K-01"), Ok(("K-01", 123.0)));
+    assert_eq!(parser("abc"), Err(Err::Error(("abc", ErrorKind::Float))));
+  }
 }

--- a/src/sequence/mod.rs
+++ b/src/sequence/mod.rs
@@ -15,17 +15,7 @@ use crate::{Check, OutputM, OutputMode, PResult};
 /// * `second` The second parser to apply.
 ///
 /// # Example
-/// ```rust
-/// use nom::sequence::pair;
-/// use nom::bytes::complete::tag;
-/// use nom::{error::ErrorKind, Err, Parser};
-///
-/// let mut parser = pair(tag("abc"), tag("efg"));
-///
-/// assert_eq!(parser.parse("abcefg"), Ok(("", ("abc", "efg"))));
-/// assert_eq!(parser.parse("abcefghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser.parse("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_1"},ignore
 /// ```
 pub fn pair<I, O1, O2, E: ParseError<I>, F, G>(
   first: F,
@@ -45,18 +35,7 @@ where
 /// * `first` The opening parser.
 /// * `second` The second parser to get object.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::sequence::preceded;
-/// use nom::bytes::complete::tag;
-///
-/// let mut parser = preceded(tag("abc"), tag("efg"));
-///
-/// assert_eq!(parser.parse("abcefg"), Ok(("", "efg")));
-/// assert_eq!(parser.parse("abcefghij"), Ok(("hij", "efg")));
-/// assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser.parse("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_2"},ignore
 /// ```
 pub fn preceded<I, O, E: ParseError<I>, F, G>(
   first: F,
@@ -102,18 +81,7 @@ impl<I, E: ParseError<I>, F: Parser<I, Error = E>, G: Parser<I, Error = E>> Pars
 /// * `first` The first parser to apply.
 /// * `second` The second parser to match an object.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::sequence::terminated;
-/// use nom::bytes::complete::tag;
-///
-/// let mut parser = terminated(tag("abc"), tag("efg"));
-///
-/// assert_eq!(parser.parse("abcefg"), Ok(("", "abc")));
-/// assert_eq!(parser.parse("abcefghij"), Ok(("hij", "abc")));
-/// assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser.parse("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_3"},ignore
 /// ```
 pub fn terminated<I, O, E: ParseError<I>, F, G>(
   first: F,
@@ -161,18 +129,7 @@ impl<I, E: ParseError<I>, F: Parser<I, Error = E>, G: Parser<I, Error = E>> Pars
 /// * `sep` The separator parser to apply.
 /// * `second` The second parser to apply.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::sequence::separated_pair;
-/// use nom::bytes::complete::tag;
-///
-/// let mut parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
-///
-/// assert_eq!(parser.parse("abc|efg"), Ok(("", ("abc", "efg"))));
-/// assert_eq!(parser.parse("abc|efghij"), Ok(("hij", ("abc", "efg"))));
-/// assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser.parse("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_4"},ignore
 /// ```
 pub fn separated_pair<I, O1, O2, E: ParseError<I>, F, G, H>(
   first: F,
@@ -196,18 +153,7 @@ where
 /// * `second` The second parser to apply.
 /// * `third` The third parser to apply and discard.
 ///
-/// ```rust
-/// # use nom::{Err, error::ErrorKind, Needed, Parser};
-/// # use nom::Needed::Size;
-/// use nom::sequence::delimited;
-/// use nom::bytes::complete::tag;
-///
-/// let mut parser = delimited(tag("("), tag("abc"), tag(")"));
-///
-/// assert_eq!(parser.parse("(abc)"), Ok(("", "abc")));
-/// assert_eq!(parser.parse("(abc)def"), Ok(("def", "abc")));
-/// assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
-/// assert_eq!(parser.parse("123"), Err(Err::Error(("123", ErrorKind::Tag))));
+/// ```rust,{source="doctests::example_5"},ignore
 /// ```
 pub fn delimited<I, O, E: ParseError<I>, F, G, H>(
   first: F,
@@ -303,14 +249,7 @@ impl<I, E: ParseError<I>> Tuple<I, (), E> for () {
 
 ///Applies a tuple of parsers one by one and returns their results as a tuple.
 ///There is a maximum of 21 parsers
-/// ```rust
-/// # use nom::{Err, error::ErrorKind};
-/// use nom::sequence::tuple;
-/// use nom::character::complete::{alpha1, digit1};
-/// let mut parser = tuple((alpha1, digit1, alpha1));
-///
-/// assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
-/// assert_eq!(parser("123def"), Err(Err::Error(("123def", ErrorKind::Alpha))));
+/// ```rust,{sourc="doctests::example_6"},ignore
 /// ```
 #[deprecated(since = "8.0.0", note = "`Parser` is directly implemented for tuples")]
 #[allow(deprecated)]
@@ -318,4 +257,105 @@ pub fn tuple<I, O, E: ParseError<I>, List: Tuple<I, O, E>>(
   mut l: List,
 ) -> impl FnMut(I) -> IResult<I, O, E> {
   move |i: I| l.parse_tuple(i)
+}
+
+#[cfg(any(doc, test))]
+mod doctests {
+  use crate as nom;
+  use nom::Needed::Size;
+  use nom::{error::ErrorKind, Err, Needed, Parser};
+
+  #[test]
+  fn example_1() {
+    use nom::bytes::complete::tag;
+    use nom::sequence::pair;
+    use nom::{error::ErrorKind, Err, Parser};
+
+    let mut parser = pair(tag("abc"), tag("efg"));
+
+    assert_eq!(parser.parse("abcefg"), Ok(("", ("abc", "efg"))));
+    assert_eq!(parser.parse("abcefghij"), Ok(("hij", ("abc", "efg"))));
+    assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
+    assert_eq!(
+      parser.parse("123"),
+      Err(Err::Error(("123", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_2() {
+    use nom::bytes::complete::tag;
+    use nom::sequence::preceded;
+
+    let mut parser = preceded(tag("abc"), tag("efg"));
+
+    assert_eq!(parser.parse("abcefg"), Ok(("", "efg")));
+    assert_eq!(parser.parse("abcefghij"), Ok(("hij", "efg")));
+    assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
+    assert_eq!(
+      parser.parse("123"),
+      Err(Err::Error(("123", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_3() {
+    use nom::bytes::complete::tag;
+    use nom::sequence::terminated;
+
+    let mut parser = terminated(tag("abc"), tag("efg"));
+
+    assert_eq!(parser.parse("abcefg"), Ok(("", "abc")));
+    assert_eq!(parser.parse("abcefghij"), Ok(("hij", "abc")));
+    assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
+    assert_eq!(
+      parser.parse("123"),
+      Err(Err::Error(("123", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_4() {
+    use nom::bytes::complete::tag;
+    use nom::sequence::separated_pair;
+
+    let mut parser = separated_pair(tag("abc"), tag("|"), tag("efg"));
+
+    assert_eq!(parser.parse("abc|efg"), Ok(("", ("abc", "efg"))));
+    assert_eq!(parser.parse("abc|efghij"), Ok(("hij", ("abc", "efg"))));
+    assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
+    assert_eq!(
+      parser.parse("123"),
+      Err(Err::Error(("123", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_5() {
+    use nom::bytes::complete::tag;
+    use nom::sequence::delimited;
+
+    let mut parser = delimited(tag("("), tag("abc"), tag(")"));
+
+    assert_eq!(parser.parse("(abc)"), Ok(("", "abc")));
+    assert_eq!(parser.parse("(abc)def"), Ok(("def", "abc")));
+    assert_eq!(parser.parse(""), Err(Err::Error(("", ErrorKind::Tag))));
+    assert_eq!(
+      parser.parse("123"),
+      Err(Err::Error(("123", ErrorKind::Tag)))
+    );
+  }
+
+  #[test]
+  fn example_6() {
+    use nom::character::complete::{alpha1, digit1};
+    use nom::sequence::tuple;
+    let mut parser = tuple((alpha1, digit1, alpha1));
+
+    assert_eq!(parser("abc123def"), Ok(("", ("abc", "123", "def"))));
+    assert_eq!(
+      parser("123def"),
+      Err(Err::Error(("123def", ErrorKind::Alpha)))
+    );
+  }
 }


### PR DESCRIPTION
Howdy, nom devs!

I'm currently working on an experiment rustdoc feature to improve the ergonomics of authoring doctests. I've gotten far enough that I'm starting to look for feedback from the wider community. I spent a bit of time searching for projects that make extensive use of doctests and nom came up pretty quick based on some random searching.

As such, I've spent a few hours today refactoring nom's extensive doctest suite to use my branch of librustdoc. So far I have the basics down, but after porting all 300 or so nom doctests, I've definitely got a few ideas on things to improve. However, I'd like to hear from folks that aren't me on whether they think this approach is even worth it. With that out of the way, here's my elevator pitch:

Writing doctests is a pain in the rear end. Rather than write Rust in code blocks with all of the issues that entails (non-awesome editor support, one test per binary, tedious setup code elision, etc) I'm proposing that instead we just write example code in a conditionally compiled module similar to unit tests (in fact, for anyone that wants to, they could just reuse unit tests for examples).

My current approach re-uses the existing doctest machinery for specifying which function to render in a code block. This has a number of issues but it at least serves to show the idea. Personally, I think this feature would likely be better having new syntax separate from fenced code blocks, but I'll leave that for the bike shedding thread it'll surely entail as its not extremely important in the grand scheme of things.

The basic idea is that in doc comments we can use syntax like such:

```rust
    /// Some docs for my_fun
    ///
    /// ```rust,{source="some_module::some_function"}
    /// ```
    fn my_fun() {
    }

    #[cfg(test)]
    mod some_module {
        #[test]
        fn some_function() {
            // Only the body of this function is rendered in the doc comment.
            println!("Hello, full editor support for code examples!");
        }
    }
```

And that's pretty much the gist of it. So far I've ported every nom doc test (that's not marked no_compile) without issue, so that at least shows the basics are there.

After porting the nom doctest suite to my experimental approach, I've certainly noticed a few things. First, I don't know nom internals so when I started this work I ended up just using a `doctests` module in the same source file and then enumerating every example as `example_1, example_2, ... example_$n`. In hindsight I should have mirrored the function name with the function being documented. However, I didn't want to bother going back once I figured that out, and it likely would have added a significant amount of time since I with the numbering scheme I was able to jump up and down pretty quickly and mechanically. However, just note that my use of the `doctests` module name and the `example_$n` pattern are completely arbitrary. If this feature goes anywhere, folks will be able to do whatever they want with their naming schemes.

Secondly, there should absolutely be an option to automatically link the function being documented with a function of the same name in some configurable module name (i.e., have a setting for "find all examples in the nested doctests module" or similar). Then we could just add syntax for where to insert the example. For multiple examples in a given doc comment I'm thinking to just add `_0, _1, _2` or similar syntax where `_0` is equivalent to having elided the suffix altogether. This obviously won't work for examples on things that aren't functions, but we'd still have the fall back syntax to specify them manually in those cases.

Thirdly, I did manage to uncover a few odd issues with various tests. Almost all of the clippy issues were simple unused imports, but there were a few deprecation warnings and the like. So I do think that suggests this approach could be generally useful to keeping code examples compiling and tested. However, I will note that @kpreid pointed out on the rust-lang Zulip chat that one significant drawback of this approach is that we're no longer compiling doctests externally to the crate under test. This means that (as it stands) we'd be losing the assertions that all of the examples work against the public API without using internals accidentally. I'm pretty sure that can be mitigated with either more rustdoc hacking or possibly with new separate tooling. However, I haven't currently got an actual working solution to that issue. If anyone can think of similar issues like that, I'd be happy to hear them.

All that said, here are a few links if anyone is interested:

1. [My librustdoc branch](https://github.com/rust-lang/rust/compare/master...davisp:rust:pd/add-doctest-source-attribute)
2. [This nom PR rendered with my branch](https://davisp.github.io/doctest-example/nom/index.html)

Also, I collected some timing and coverage numbers before and after this work. I'll paste those down below.

And finally, if the nom devs find this PR an affront to their senses and want to pretend it never existed, feel free to close this PR and we'll never speak of it again. I'm hoping that nom's large doctest suite means y'all would be interested in exploring easier maintenance of it, but I'll be the first to admit I might be tilting at windmills here. Nom was just the first large doctest suite I found on a popular project, so apologies if this is beyond the pale or anything of that nature.

A note on the test timings, it turns out that my branch breaks if I `ignore` the doctest instead of marking them `no_run`. I'm still learning the rustc toolchain internals and have not managed to figure out why building rustdoc results in a binary that appears to have no idea about the `test` configuration option which means that I'm running the test suite with the stable toolchain. Point being, of the 13s measured, roughly 11s of that is just compiling the doctests. In real life these won't actually show up there and instead will just be listed in the normal unit test output which executes ~instantly. The rest of the 2s or so when using `ignore` is the integration tests.

# main - Test Timing

```
$ time cargo test
cargo test  35.40s user 13.07s system 101% cpu 47.671 total
```

# main - Coverage

```
$ cargo llvm-cov clean --workspace
$ cargo llvm-cov --no-report --tests
$ cargo +nightly llvm-cov --no-report --doctests
$ cargo +nightly llvm-cov report --summary-only --doctests
```

```
Filename                               Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
nom-language/src/error.rs                   51                51     0.00%          16                16     0.00%         139               139     0.00%           0                 0         -
nom-language/src/precedence/mod.rs         129                53    58.91%          15                 5    66.67%         234                99    57.69%           0                 0         -
src/bits/complete.rs                        60                 9    85.00%          16                 3    81.25%         141                23    83.69%           0                 0         -
src/bits/mod.rs                             55                 9    83.64%          13                 0   100.00%         110                 8    92.73%           0                 0         -
src/bits/streaming.rs                       53                 1    98.11%          14                 0   100.00%         128                 1    99.22%           0                 0         -
src/branch/mod.rs                           81                16    80.25%          24                 5    79.17%         114                29    74.56%           0                 0         -
src/branch/tests.rs                         47                 3    93.62%          20                 3    85.00%         115                 9    92.17%           0                 0         -
src/bytes/complete.rs                      176                 0   100.00%          71                 0   100.00%         335                 0   100.00%           0                 0         -
src/bytes/mod.rs                           306                51    83.33%          91                 5    94.51%         614                87    85.83%           0                 0         -
src/bytes/streaming.rs                     143                 0   100.00%          59                 0   100.00%         280                 0   100.00%           0                 0         -
src/bytes/tests.rs                         243                 1    99.59%          75                 0   100.00%         500                 0   100.00%           0                 0         -
src/character/complete.rs                  508                24    95.28%         125                 1    99.20%         883                29    96.72%           0                 0         -
src/character/mod.rs                       151                46    69.54%          50                13    74.00%         223                67    69.96%           0                 0         -
src/character/streaming.rs                 485                18    96.29%         102                 0   100.00%         863                24    97.22%           0                 0         -
src/character/tests.rs                      23                 0   100.00%           9                 0   100.00%          41                 0   100.00%           0                 0         -
src/combinator/mod.rs                      149                 8    94.63%          61                 0   100.00%         385                12    96.88%           0                 0         -
src/combinator/tests.rs                     85                 9    89.41%          33                 6    81.82%         187                17    90.91%           0                 0         -
src/error.rs                               171               128    25.15%          38                10    73.68%         297               161    45.79%           0                 0         -
src/internal.rs                            187                47    74.87%          64                16    75.00%         300                84    72.00%           0                 0         -
src/lib.rs                                 123                29    76.42%          51                17    66.67%         255               145    43.14%           0                 0         -
src/multi/mod.rs                           497                55    88.93%         140                 9    93.57%        1159                82    92.92%           0                 0         -
src/multi/tests.rs                         250                 3    98.80%          79                 3    96.20%         699                 9    98.71%           0                 0         -
src/number/complete.rs                     708                70    90.11%         227                 3    98.68%        1360                75    94.49%           0                 0         -
src/number/mod.rs                          489                33    93.25%         170                 8    95.29%         948                52    94.51%           0                 0         -
src/number/streaming.rs                    736                73    90.08%         220                 3    98.64%        1468                76    94.82%           0                 0         -
src/sequence/mod.rs                         68                 3    95.59%          20                 2    90.00%         137                 4    97.08%           0                 0         -
src/sequence/tests.rs                       71                 1    98.59%          16                 0   100.00%         209                 0   100.00%           0                 0         -
src/str.rs                                 172                35    79.65%          43                 0   100.00%         324               108    66.67%           0                 0         -
src/traits.rs                              494               178    63.97%         208                84    59.62%         920               327    64.46%           0                 0         -
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                     6711               954    85.78%        2070               212    89.76%       13368              1667    87.53%           0                 0         -
```

# pd/experimental-rustdoc - Test Timing

```
$ time cargo test
cargo test  18.29s user 8.61s system 206% cpu 13.030 total
```

# pd/experimental-rustdoc - Coverage

```
$ cargo llvm-cov clean --workspace
$ cargo llvm-cov --no-report --tests
$ cargo +nightly llvm-cov --no-report --doctests
$ cargo +nightly llvm-cov report --summary-only --doctests
```

```
Filename                               Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
nom-language/src/error.rs                   51                51     0.00%          16                16     0.00%         139               139     0.00%           0                 0         -
nom-language/src/precedence/mod.rs         129                53    58.91%          15                 5    66.67%         234                99    57.69%           0                 0         -
src/bits/complete.rs                        58                 9    84.48%          15                 3    80.00%         160                23    85.62%           0                 0         -
src/bits/mod.rs                             53                 9    83.02%          12                 0   100.00%         108                 8    92.59%           0                 0         -
src/bits/streaming.rs                       51                 1    98.04%          13                 0   100.00%         132                 1    99.24%           0                 0         -
src/branch/mod.rs                           87                18    79.31%          26                 5    80.77%         131                30    77.10%           0                 0         -
src/branch/tests.rs                         47                 3    93.62%          20                 3    85.00%         115                 9    92.17%           0                 0         -
src/bytes/complete.rs                      174                 0   100.00%          70                 0   100.00%         384                 0   100.00%           0                 0         -
src/bytes/mod.rs                           304                51    83.22%          90                 5    94.44%         654                87    86.70%           0                 0         -
src/bytes/streaming.rs                     141                 0   100.00%          58                 0   100.00%         317                 0   100.00%           0                 0         -
src/bytes/tests.rs                         243                 1    99.59%          75                 0   100.00%         500                 0   100.00%           0                 0         -
src/character/complete.rs                  505                91    81.98%         124                 8    93.55%         980               123    87.45%           0                 0         -
src/character/mod.rs                       145                46    68.28%          49                13    73.47%         254                67    73.62%           0                 0         -
src/character/streaming.rs                 460                93    79.78%         101                 8    92.08%        1008               125    87.60%           0                 0         -
src/character/tests.rs                      23                 0   100.00%           9                 0   100.00%          41                 0   100.00%           0                 0         -
src/combinator/mod.rs                      250                 8    96.80%          87                 0   100.00%         606                12    98.02%           0                 0         -
src/combinator/tests.rs                     85                 9    89.41%          33                 6    81.82%         187                17    90.91%           0                 0         -
src/error.rs                               169               128    24.26%          37                10    72.97%         295               161    45.42%           0                 0         -
src/internal.rs                            187                48    74.33%          64                16    75.00%         300                85    71.67%           0                 0         -
src/lib.rs                                 152                31    79.61%          60                17    71.67%         342               145    57.60%           0                 0         -
src/multi/mod.rs                           495                55    88.89%         139                 9    93.53%        1199                82    93.16%           0                 0         -
src/multi/tests.rs                         250                 3    98.80%          79                 3    96.20%         699                 9    98.71%           0                 0         -
src/number/complete.rs                     706                75    89.38%         226                 4    98.23%        1515                83    94.52%           0                 0         -
src/number/mod.rs                          487                33    93.22%         169                 8    95.27%         987                52    94.73%           0                 0         -
src/number/streaming.rs                    734                82    88.83%         219                 5    97.72%        1486                86    94.21%           0                 0         -
src/sequence/mod.rs                         66                 3    95.45%          19                 2    89.47%         153                 4    97.39%           0                 0         -
src/sequence/tests.rs                       71                 1    98.59%          16                 0   100.00%         209                 0   100.00%           0                 0         -
src/str.rs                                 172                35    79.65%          43                 0   100.00%         324               108    66.67%           0                 0         -
src/traits.rs                              494               179    63.77%         208                85    59.13%         920               330    64.13%           0                 0         -
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                     6789              1116    83.56%        2092               231    88.96%       14379              1885    86.89%           0                 0         -```