### PR TITLE
ParseTo no longer uses a generic

### DIFF
--- a/src/number/complete.rs
+++ b/src/number/complete.rs
@@ -1407,7 +1407,7 @@ use crate::traits::ParseTo;
 /// ```
 pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
-  T: Clone + Offset + ParseTo<f32> + Compare<&'static str>,
+  T: Clone + Offset + ParseTo + Compare<&'static str>,
   T: Input,
   <T as Input>::Item: AsChar,
   <T as Input>::Iter: Clone,
@@ -1457,7 +1457,7 @@ where
 /// ```
 pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
-  T: Clone + Offset + ParseTo<f64> + Compare<&'static str>,
+  T: Clone + Offset + ParseTo + Compare<&'static str>,
   T: Input,
   <T as Input>::Item: AsChar,
   <T as Input>::Iter: Clone,

--- a/src/number/mod.rs
+++ b/src/number/mod.rs
@@ -3,6 +3,7 @@
 use core::{
   marker::PhantomData,
   ops::{Add, Shl},
+  str::FromStr,
 };
 
 use crate::{
@@ -1350,7 +1351,7 @@ where
 pub fn float<T, E: ParseError<T>>() -> impl Parser<T, Output = f32, Error = E>
 where
   T: Clone + Offset,
-  T: Input + crate::traits::ParseTo<f32> + Compare<&'static str>,
+  T: Input + crate::traits::ParseTo + Compare<&'static str>,
   <T as Input>::Item: AsChar + Clone,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
@@ -1365,7 +1366,7 @@ where
 pub fn double<T, E: ParseError<T>>() -> impl Parser<T, Output = f64, Error = E>
 where
   T: Clone + Offset,
-  T: Input + crate::traits::ParseTo<f64> + Compare<&'static str>,
+  T: Input + crate::traits::ParseTo + Compare<&'static str>,
   <T as Input>::Item: AsChar + Clone,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
@@ -1385,10 +1386,11 @@ struct Float<O, E> {
 impl<I, O, E: ParseError<I>> Parser<I> for Float<O, E>
 where
   I: Clone + Offset,
-  I: Input + crate::traits::ParseTo<O> + Compare<&'static str>,
+  I: Input + crate::traits::ParseTo + Compare<&'static str>,
   <I as Input>::Item: AsChar + Clone,
   I: AsBytes,
   I: for<'a> Compare<&'a [u8]>,
+  O: FromStr,
 {
   type Output = O;
   type Error = E;

--- a/src/number/streaming.rs
+++ b/src/number/streaming.rs
@@ -8,7 +8,7 @@ use crate::error::{ErrorKind, ParseError};
 use crate::lib::std::ops::{Add, Shl};
 use crate::sequence::pair;
 use crate::traits::{AsBytes, AsChar, Compare, Offset};
-use crate::{internal::*, Input};
+use crate::{internal::*, Input, ParseTo};
 
 /// Recognizes an unsigned 1 byte integer.
 ///
@@ -1377,7 +1377,7 @@ where
 pub fn float<T, E: ParseError<T>>(input: T) -> IResult<T, f32, E>
 where
   T: Clone + Offset,
-  T: Input + crate::traits::ParseTo<f32> + Compare<&'static str>,
+  T: Input + ParseTo + Compare<&'static str>,
   <T as Input>::Item: AsChar + Clone,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,
@@ -1427,7 +1427,7 @@ where
 pub fn double<T, E: ParseError<T>>(input: T) -> IResult<T, f64, E>
 where
   T: Clone + Offset,
-  T: Input + crate::traits::ParseTo<f64> + Compare<&'static str>,
+  T: Input + ParseTo + Compare<&'static str>,
   <T as Input>::Item: AsChar + Clone,
   T: AsBytes,
   T: for<'a> Compare<&'a [u8]>,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1078,20 +1078,20 @@ impl<'a, 'b> FindSubstring<&'b str> for &'a str {
 }
 
 /// Used to integrate `str`'s `parse()` method
-pub trait ParseTo<R> {
+pub trait ParseTo {
   /// Succeeds if `parse()` succeeded. The byte slice implementation
   /// will first convert it to a `&str`, then apply the `parse()` function
-  fn parse_to(&self) -> Option<R>;
+  fn parse_to<R: FromStr>(&self) -> Option<R>;
 }
 
-impl<'a, R: FromStr> ParseTo<R> for &'a [u8] {
-  fn parse_to(&self) -> Option<R> {
+impl<'a> ParseTo for &'a [u8] {
+  fn parse_to<R: FromStr>(&self) -> Option<R> {
     from_utf8(self).ok().and_then(|s| s.parse().ok())
   }
 }
 
-impl<'a, R: FromStr> ParseTo<R> for &'a str {
-  fn parse_to(&self) -> Option<R> {
+impl<'a> ParseTo for &'a str {
+  fn parse_to<R: FromStr>(&self) -> Option<R> {
     self.parse().ok()
   }
 }


### PR DESCRIPTION
See https://github.com/rust-bakery/nom/issues/1805 for a description of the issue. This change makes it way easier to deal with the `ParseTo` trait.