### PR TITLE
Fix for issue 1808

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -462,7 +462,7 @@ impl<'a> Input for &'a str {
         let (str1, str2) = self.split_at(i);
         Ok((str2, str1))
       }
-      None => Ok(self.split_at(0)),
+      None => Ok(self.take_split(self.input_len())),
     }
   }
 

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -269,3 +269,15 @@ fn issue_1586_parser_iterator_impl() {
 
   assert_eq!(parse_input("123\n456").collect::<Vec<_>>(), vec![123, 456]);
 }
+
+#[test]
+fn issue_1808_complete_string_parser_returns_wrong_slice() {
+  use nom::character::complete::multispace0;
+  use nom::combinator::recognize;
+
+  let input = "\n";
+  assert_eq!(
+    recognize::<_, nom::error::Error<_>, _>(multispace0).parse(input),
+    Ok(("", "\n"))
+  );
+}


### PR DESCRIPTION
It turned out that the `split_at_position_complete` for str returned the beginning of the string with length 0, instead of the end. This broke the offset calculations.

Fixes https://github.com/rust-bakery/nom/issues/1808