### PR TITLE
Fix a doc typo

### DIFF
--- a/src/bytes/complete.rs
+++ b/src/bytes/complete.rs
@@ -111,7 +111,7 @@ where
   move |i: I| parser.process::<OutputM<Emit, Emit, Complete>>(i)
 }
 
-/// Returns the longest slice of the matches the pattern.
+/// Returns the longest input slice (at least 1) that matches the pattern.
 ///
 /// The parser will return the longest slice consisting of the characters in provided in the
 /// combinator's argument.

--- a/src/bytes/mod.rs
+++ b/src/bytes/mod.rs
@@ -237,7 +237,7 @@ where
   }
 }
 
-/// Returns the longest slice of the matches the pattern.
+/// Returns the longest input slice (at least 1) that matches the pattern.
 ///
 /// The parser will return the longest slice consisting of the characters in provided in the
 /// combinator's argument.

--- a/src/bytes/streaming.rs
+++ b/src/bytes/streaming.rs
@@ -108,7 +108,7 @@ where
   move |i: I| parser.process::<OutputM<Emit, Emit, Streaming>>(i)
 }
 
-/// Returns the longest slice of the matches the pattern.
+/// Returns the longest input slice (at least 1) that matches the pattern.
 ///
 /// The parser will return the longest slice consisting of the characters in provided in the
 /// combinator's argument.


### PR DESCRIPTION
Fixes a minor documentation typo in `is_a`. I made sure that that exact typo isn't anywhere else, but I didn't check for any other typos. I used the same language used in `take_till` and family.

(Thanks for v8.0, btw, it looks great!)