### PR TITLE
Add `tergo` - an R programming language parser and tokenizer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Here is a (non exhaustive) list of known projects using nom:
 [Wasm](https://github.com/fabrizio-m/wasm-nom),
 [Pseudocode](https://github.com/Gungy2/pseudocod),
 [Filter for MeiliSearch](https://github.com/meilisearch/meilisearch),
-[PotterScript](https://github.com/fmiras/potterscript)
+[PotterScript](https://github.com/fmiras/potterscript),
+[R](https://github.com/kpagacz/tergo)
 - Interface definition formats: [Thrift](https://github.com/thehydroimpulse/thrust)
 - Audio, video and image formats:
 [GIF](https://github.com/Geal/gif.rs),


### PR DESCRIPTION
Hello all,

this does not have an issue number because it's just a change in the README.

I am the author of `tergo` - a code formatter for R written in Rust. As part of the project, I rolled my own parser for the language using `nom`. I kindly ask you to include my project in the list of programming language parsers.

Kind regards
Konrad